### PR TITLE
Fix bug in substitute

### DIFF
--- a/src/dot.rs
+++ b/src/dot.rs
@@ -51,6 +51,6 @@ fn add_edge_str<N: Display, E: Display>(
     });
 
     let edge = graph.edge_weight(e).expect("missing edge");
-    let edge_s = format!("{} -> {} [label=\"({}, {}); {}\"]\n", a, b, ap, bp, edge);
+    let edge_s = format!("{a} -> {b} [label=\"({ap}, {bp}); {edge}\"]\n");
     dot_s.push_str(&edge_s[..])
 }

--- a/src/substitute.rs
+++ b/src/substitute.rs
@@ -126,19 +126,19 @@ impl<N: Default + Debug + Display, E: Debug + Display> Graph<N, E> {
         let removed = self.remove_subgraph(&subgraph);
 
         // insert new graph and update edge references accordingly
-        let (_, edge_map) = self.insert_graph(replacement.graph);
+        let (_, mut edge_map) = self.insert_graph(replacement.graph);
 
         for direction in DIRECTIONS {
             let edges = &subgraph.edges[direction.index()];
             let ports = &replacement.ports[direction.index()];
 
             for (edge, port) in edges.iter().zip(ports) {
-                let port = edge_map[port];
-
                 // TODO: There should be a check to make sure this can not fail
                 // before we merge the first edge to avoid leaving the graph in an
                 // invalid state.
-                self.merge_edges(port, *edge).unwrap();
+                self.merge_edges(edge_map[port], *edge).unwrap();
+                // Update edge_map to point to new merged edge
+                edge_map.get_mut(port).map(|e| *e = *edge);
             }
         }
 

--- a/src/substitute.rs
+++ b/src/substitute.rs
@@ -138,7 +138,9 @@ impl<N: Default + Debug + Display, E: Debug + Display> Graph<N, E> {
                 // invalid state.
                 self.merge_edges(edge_map[repl_edge], *sub_edge).unwrap();
                 // Update edge_map to point to new merged edge
-                edge_map.get_mut(repl_edge).map(|e| *e = *sub_edge);
+                if let Some(e) = edge_map.get_mut(repl_edge) {
+                    *e = *sub_edge;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes a bug when merging edges in an empty graph in the `substitute` module.
It also fixes the clippy warnings