### PR TITLE
Fixes to the graph component modules

### DIFF
--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -1,3 +1,54 @@
+//! Hierarchical structure on top of a [`PortGraph`]. This is a separate
+//! relation from the graph's adjacency.
+//!
+//! The nodes form a forest, with each node having at most a single parent, and
+//! any number of children. Cycles are not allowed.
+//!
+//! This map does not allocate any memory until a value is modified. It is
+//! intended to be used alongside [`PortGraph`], as it does not keep track of
+//! key validity.
+//!
+//! [`PortGraph`]: crate::portgraph::PortGraph
+//!
+//! # Example
+//!
+//! ```
+//! # use portgraph::{PortGraph, NodeIndex, PortIndex};
+//! # use portgraph::hierarchy::Hierarchy;
+//! let mut graph = PortGraph::new();
+//! let mut hierarchy = Hierarchy::new();
+//!
+//! let parent = graph.add_node(0, 0);
+//! assert!(hierarchy.is_root(parent));
+//! assert_eq!(hierarchy.child_count(parent), 0);
+//!
+//! // Add some children.
+//! let child_0 = graph.add_node(0, 0);
+//! let child_1 = graph.add_node(0, 0);
+//! hierarchy.attach_first(child_1, parent).unwrap();
+//! hierarchy.attach_before(child_0, child_1).unwrap();
+//!
+//! assert_eq!(hierarchy.child_count(parent), 2);
+//! assert_eq!(hierarchy.children(parent).collect::<Vec<_>>(), vec![child_0, child_1]);
+//!
+//! assert_eq!(hierarchy.parent(child_0), Some(parent));
+//! assert_eq!(hierarchy.prev(child_0), None);
+//! assert_eq!(hierarchy.next(child_0), Some(child_1));
+//!
+//! // Modifications to the graph must be manually propagated to the hierarchy.
+//! graph.remove_node(parent);
+//! hierarchy.remove(parent);
+//!
+//! assert!(hierarchy.is_root(child_0));
+//! assert!(hierarchy.is_root(child_1));
+//! assert_eq!(hierarchy.next(child_0), None);
+//!
+//! graph.compact_nodes(|old, new| {
+//!     hierarchy.rekey(old, new);
+//! });
+//! hierarchy.shrink_to(graph.node_count());
+//! ```
+
 use std::iter::FusedIterator;
 use std::mem::{replace, take};
 use thiserror::Error;
@@ -130,7 +181,7 @@ impl Hierarchy {
         }
 
         let Some(parent) = self.get(before).parent else {
-            return Err(AttachError::RelativeToRoot);
+            return Err(AttachError::RootSibling);
         };
 
         if !self.cycle_check(node, parent) {
@@ -171,7 +222,7 @@ impl Hierarchy {
         }
 
         let Some(parent) = self.get(after).parent else {
-            return Err(AttachError::RelativeToRoot);
+            return Err(AttachError::RootSibling);
         };
 
         if !self.cycle_check(node, parent) {
@@ -246,6 +297,7 @@ impl Hierarchy {
 
         node_data.children_count = 0;
         let mut child_next = node_data.children[0];
+        node_data.children = [None, None];
 
         while let Some(child) = child_next {
             let child_data = self.get_mut(child);
@@ -255,10 +307,23 @@ impl Hierarchy {
         }
     }
 
+    /// Removes a node from the hierarchy, detaching it from its parent and
+    /// detaching all its children.
+    pub fn remove(&mut self, node: NodeIndex) {
+        self.detach_children(node);
+        self.detach(node);
+    }
+
     /// Returns a node's parent or `None` if it is a root.
     #[inline]
     pub fn parent(&self, node: NodeIndex) -> Option<NodeIndex> {
         self.get(node).parent
+    }
+
+    /// Returns whether a node is a root.
+    #[inline]
+    pub fn is_root(&self, node: NodeIndex) -> bool {
+        self.parent(node).is_none()
     }
 
     /// Returns a node's first child, if any.
@@ -340,6 +405,7 @@ impl Hierarchy {
         }
 
         *self.get_mut(new) = node_data;
+        *self.get_mut(old) = NodeData::default();
     }
 
     /// Reserves enough capacity to fit a maximum node index without reallocating.
@@ -348,7 +414,16 @@ impl Hierarchy {
         self.data.ensure_capacity(capacity);
     }
 
-    // TODO: API to shrink
+    /// Reduces the capacity of the structure to `capacity`.
+    /// Nodes with index higher than `capacity` are disconnected.
+    ///
+    /// Does nothing when the capacity of the secondary map is already lower.
+    pub fn shrink_to(&mut self, capacity: usize) {
+        for node in (capacity..self.data.capacity()).rev() {
+            self.remove(NodeIndex::new(node));
+        }
+        self.data.shrink_to(capacity);
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -359,7 +434,7 @@ struct NodeData {
     children_count: u32,
     /// The parent of a node, if any.
     parent: Option<NodeIndex>,
-    /// The sibilings of a node, if any.
+    /// The siblings of a node, if any.
     siblings: [Option<NodeIndex>; 2],
 }
 
@@ -431,12 +506,207 @@ impl<'a> ExactSizeIterator for Children<'a> {
 
 impl<'a> FusedIterator for Children<'a> {}
 
+/// Error produced when trying to attach nodes in the Hierarchy.
 #[derive(Debug, Clone, Error)]
 pub enum AttachError {
+    /// The node is already attached to a parent.
     #[error("the node is already attached")]
     AlreadyAttached,
-    #[error("can not attach relative to a root node")]
-    RelativeToRoot,
+    /// The target node is a root node, and cannot have siblings.
+    #[error("Can not attach a sibling to a root node")]
+    RootSibling,
+    /// The relation would introduce a cycle.
     #[error("attaching the node would introduce a cycle")]
     Cycle,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::PortGraph;
+
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        let mut hierarchy = Hierarchy::new();
+        let root = NodeIndex::new(4);
+
+        assert_eq!(hierarchy.child_count(root), 0);
+        assert_eq!(hierarchy.parent(root), None);
+        assert_eq!(hierarchy.first(root), None);
+        assert_eq!(hierarchy.last(root), None);
+        assert_eq!(hierarchy.next(root), None);
+        assert_eq!(hierarchy.prev(root), None);
+
+        let child0 = NodeIndex::new(0);
+        let child1 = NodeIndex::new(1);
+        let child2 = NodeIndex::new(2);
+        let children = [child0, child1, child2];
+        hierarchy.attach_first(child0, root).unwrap();
+        hierarchy.attach_last(child2, root).unwrap();
+        hierarchy.attach_after(child1, child0).unwrap();
+
+        assert!(hierarchy.attach_first(root, child2).is_err());
+        assert!(hierarchy.attach_first(child2, root).is_err());
+
+        assert_eq!(hierarchy.child_count(root), 3);
+        assert_eq!(
+            hierarchy.children(root).collect::<Vec<_>>(),
+            vec![child0, child1, child2]
+        );
+        assert_eq!(hierarchy.parent(root), None);
+        assert_eq!(hierarchy.first(root), Some(child0));
+        assert_eq!(hierarchy.last(root), Some(child2));
+        assert_eq!(hierarchy.next(root), None);
+        assert_eq!(hierarchy.prev(root), None);
+
+        for child in children {
+            assert_eq!(hierarchy.parent(child), Some(root));
+            assert_eq!(hierarchy.child_count(child), 0);
+        }
+        assert_eq!(hierarchy.prev(child0), None);
+        assert_eq!(hierarchy.next(child0), Some(child1));
+        assert_eq!(hierarchy.prev(child1), Some(child0));
+        assert_eq!(hierarchy.next(child1), Some(child2));
+        assert_eq!(hierarchy.prev(child2), Some(child1));
+        assert_eq!(hierarchy.next(child2), None);
+    }
+
+    #[test]
+    fn test_detach() {
+        let mut hierarchy = Hierarchy::new();
+        let root = NodeIndex::new(4);
+
+        let child0 = NodeIndex::new(0);
+        let child1 = NodeIndex::new(1);
+        let child2 = NodeIndex::new(2);
+        hierarchy.attach_last(child2, root).unwrap();
+        hierarchy.attach_before(child1, child2).unwrap();
+        hierarchy.attach_before(child0, child1).unwrap();
+
+        assert_eq!(
+            hierarchy.children(root).collect::<Vec<_>>(),
+            vec![child0, child1, child2]
+        );
+
+        hierarchy.detach(child1).unwrap();
+
+        assert_eq!(
+            hierarchy.children(root).collect::<Vec<_>>(),
+            vec![child0, child2]
+        );
+
+        assert_eq!(hierarchy.prev(child0), None);
+        assert_eq!(hierarchy.next(child0), Some(child2));
+        assert_eq!(hierarchy.prev(child2), Some(child0));
+        assert_eq!(hierarchy.next(child2), None);
+
+        assert_eq!(hierarchy.parent(child1), None);
+        assert_eq!(hierarchy.prev(child1), None);
+        assert_eq!(hierarchy.next(child1), None);
+
+        hierarchy.detach_children(root);
+
+        assert_eq!(hierarchy.first(root), None);
+        assert_eq!(hierarchy.last(root), None);
+        assert_eq!(hierarchy.children(root).collect::<Vec<_>>(), vec![]);
+        for child in [child0, child2] {
+            assert_eq!(hierarchy.parent(child), None);
+            assert_eq!(hierarchy.prev(child), None);
+            assert_eq!(hierarchy.next(child), None);
+        }
+    }
+
+    #[test]
+    fn test_rekey() {
+        let mut hierarchy = Hierarchy::new();
+        let root = NodeIndex::new(4);
+
+        let child0 = NodeIndex::new(0);
+        let child1 = NodeIndex::new(1);
+        let child2 = NodeIndex::new(2);
+        hierarchy.attach_last(child2, root).unwrap();
+        hierarchy.attach_before(child1, child2).unwrap();
+        hierarchy.attach_before(child0, child1).unwrap();
+
+        assert_eq!(
+            hierarchy.children(root).collect::<Vec<_>>(),
+            vec![child0, child1, child2]
+        );
+
+        let grandchild = NodeIndex::new(42);
+        hierarchy.attach_first(grandchild, child1).unwrap();
+
+        assert_eq!(
+            hierarchy.children(root).collect::<Vec<_>>(),
+            vec![child0, child1, child2]
+        );
+        assert_eq!(
+            hierarchy.children(child1).collect::<Vec<_>>(),
+            vec![grandchild]
+        );
+
+        let new_child1 = NodeIndex::new(8);
+        hierarchy.rekey(child1, new_child1);
+
+        assert_eq!(
+            hierarchy.children(root).collect::<Vec<_>>(),
+            vec![child0, new_child1, child2]
+        );
+        assert_eq!(
+            hierarchy.children(new_child1).collect::<Vec<_>>(),
+            vec![grandchild]
+        );
+        assert_eq!(hierarchy.parent(new_child1), Some(root));
+        assert_eq!(hierarchy.parent(grandchild), Some(new_child1));
+
+        assert_eq!(hierarchy.next(child0), Some(new_child1));
+        assert_eq!(hierarchy.next(new_child1), Some(child2));
+        assert_eq!(hierarchy.prev(new_child1), Some(child0));
+        assert_eq!(hierarchy.prev(child2), Some(new_child1));
+
+        hierarchy.remove(new_child1);
+        assert_eq!(
+            hierarchy.children(root).collect::<Vec<_>>(),
+            vec![child0, child2]
+        );
+        assert!(hierarchy.is_root(grandchild));
+    }
+
+    #[test]
+    fn test_graph_compact() {
+        let mut graph = PortGraph::new();
+        let mut hierarchy = Hierarchy::new();
+
+        let parent = graph.add_node(0, 0);
+        let mut child_0 = graph.add_node(0, 0);
+        let mut child_1 = graph.add_node(0, 0);
+        hierarchy.attach_first(child_1, parent).unwrap();
+        hierarchy.attach_before(child_0, child_1).unwrap();
+
+        // Modifications to the graph must be manually propagated to the hierarchy.
+        graph.remove_node(parent);
+        hierarchy.remove(parent);
+
+        assert!(hierarchy.is_root(child_0));
+        assert!(hierarchy.is_root(child_1));
+        assert_eq!(hierarchy.next(child_0), None);
+
+        hierarchy.attach_first(child_1, child_0).unwrap();
+
+        graph.compact_nodes(|old, new| {
+            hierarchy.rekey(old, new);
+            if old == child_0 {
+                child_0 = new;
+            } else if old == child_1 {
+                child_1 = new;
+            }
+        });
+
+        hierarchy.shrink_to(graph.node_count());
+
+        assert!(hierarchy.is_root(child_0));
+        assert_eq!(hierarchy.first(child_0), Some(child_1));
+        assert_eq!(hierarchy.parent(child_1), Some(child_0));
+    }
 }

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -1,3 +1,46 @@
+//! A dense key-value map used to store graph weights.
+//!
+//! This map does not allocate any memory until a value is modified, returning
+//! references to the default value instead.
+//!
+//! This structure is intended to be used alongside [`PortGraph`], as it does
+//! not keep track of the valid keys.
+//!
+//! For simple cases where the nodes and ports have a single weight each, see
+//! [`portgraph::Weights`].
+//!
+//! # Example
+//!
+//! ```
+//! # use portgraph::{PortGraph, NodeIndex, PortIndex};
+//! # use portgraph::secondary::SecondaryMap;
+//!
+//! let mut graph = PortGraph::new();
+//! let mut node_weights = SecondaryMap::<NodeIndex, usize>::new();
+//! let mut port_weights = SecondaryMap::<PortIndex, isize>::new();
+//!
+//! // The weights must be set manually.
+//! let node = graph.add_node(2, 2);
+//! let [in0, in1, ..] = graph.inputs(node).collect::<Vec<_>>()[..] else { unreachable!() };
+//! let [out0, out1, ..] = graph.outputs(node).collect::<Vec<_>>()[..] else { unreachable!() };
+//! node_weights[node] = 42;
+//! port_weights[in1] = 2;
+//! port_weights[out0] = -1;
+//! port_weights[out1] = -2;
+//!
+//! /// Unset weights return the default value.
+//! assert_eq!(port_weights[in0], 0);
+//!
+//! // Graph operations that modify the keys use callbacks to update the weights.
+//! graph.set_num_ports(node, 1, 3, |old, new| {if let Some(new) = new {port_weights.swap(old, new);}});
+//!
+//! // The map do not track item removals, but the user can shrink the map manually.
+//! graph.remove_node(node);
+//! node_weights.shrink_to(graph.node_count());
+//! port_weights.shrink_to(graph.port_count());
+//!
+//! ```
+
 use std::{
     marker::PhantomData,
     mem::MaybeUninit,
@@ -5,6 +48,7 @@ use std::{
 };
 
 /// A dense map from keys to values with default fallbacks.
+///
 #[derive(Debug, Clone)]
 pub struct SecondaryMap<K, V> {
     data: Vec<V>,
@@ -63,10 +107,19 @@ where
     ///
     /// Does nothing when the capacity of the secondary map is already sufficient.
     pub fn ensure_capacity(&mut self, capacity: usize) {
-        if let Some(additional) = self.data.capacity().checked_sub(capacity) {
-            self.data.reserve(additional);
-            self.data.resize(self.data.capacity(), self.default.clone());
+        if capacity > self.data.capacity() {
+            self.data.reserve(capacity - self.data.capacity());
+            self.data.resize(capacity, self.default.clone());
         }
+    }
+
+    /// Reduces the capacity of the secondary map to `capacity`.
+    /// Stored values higher than `capacity` are dropped.
+    ///
+    /// Does nothing when the capacity of the secondary map is already lower.
+    pub fn shrink_to(&mut self, capacity: usize) {
+        self.data.truncate(capacity);
+        self.data.shrink_to_fit();
     }
 
     /// Returns the maximum index the secondary map can contain without allocating.
@@ -122,24 +175,32 @@ where
         };
 
         // Collect pointers for all indices
-        let mut ptrs: [MaybeUninit<*mut V>; N] = unsafe { MaybeUninit::uninit().assume_init() };
+        let mut ptrs: [MaybeUninit<*mut V>; N] = [MaybeUninit::uninit(); N];
 
         // NOTE: This is a quadratic check. That is not a problem for very small
         // `N` but it would be nice if it could be avoided. See
         // https://docs.rs/slotmap/latest/slotmap/struct.SlotMap.html#method.get_disjoint_mut
         // for a linear time implementation. Unfortunately their trick is not
         // applicable here since we do not have the extra tagging bit available.
+        let data = self.data.as_mut_ptr();
         for (i, key) in keys.iter().enumerate() {
-            ptrs[i] = MaybeUninit::new(&mut self.data[(*key).into()]);
-
-            if keys.iter().skip(i + 1).any(|other| key == other) {
+            if keys[(i + 1)..].iter().any(|other| key == other) {
                 return None;
             }
+
+            let offset = (*key).into();
+            if offset >= self.data.len() {
+                return None;
+            }
+            // SAFETY: The offset is within the bounds of the underlying array.
+            let ptr: *mut V = unsafe { data.add(offset) };
+            ptrs[i].write(ptr);
         }
 
         // SAFETY: The pointers come from valid borrows into the underlying
         // array and we have checked their disjointness.
-        Some(unsafe { std::mem::transmute_copy::<_, [&mut V; N]>(&keys) })
+        let refs = unsafe { ptrs.map(|p| &mut *p.assume_init()) };
+        Some(refs)
     }
 
     /// Must be called with `len` greater than `self.data.len()`.
@@ -150,7 +211,7 @@ where
 
     /// Swaps the values of two keys.
     ///
-    /// Allocates more memory when neccessary to fit the keys.
+    /// Allocates more memory when necessary to fit the keys.
     #[inline]
     pub fn swap(&mut self, key0: K, key1: K) {
         let index0 = key0.into();
@@ -194,5 +255,87 @@ where
 {
     fn index_mut(&mut self, key: K) -> &mut Self::Output {
         self.get_mut(key)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_capacity() {
+        let mut map: SecondaryMap<usize, usize> = SecondaryMap::new();
+
+        assert_eq!(map.capacity(), 0);
+
+        map.ensure_capacity(10);
+        assert!(map.capacity() >= 10);
+
+        let prev_capacity = map.capacity();
+        map.ensure_capacity(5);
+        assert_eq!(map.capacity(), prev_capacity);
+
+        map.ensure_capacity(15);
+        assert!(map.capacity() >= 15);
+
+        map.shrink_to(5);
+        assert!(map.capacity() >= 5);
+
+        let prev_capacity = map.capacity();
+        map.shrink_to(10);
+        assert_eq!(map.capacity(), prev_capacity);
+    }
+
+    #[test]
+    fn test_get_mut() {
+        let mut map: SecondaryMap<usize, i32> = SecondaryMap::with_default(4);
+
+        let value = map.get_mut(0);
+        assert_eq!(value, &4);
+        *value = 1;
+        assert_eq!(map.get_mut(0), &1);
+
+        let value = map.try_get_mut(10);
+        assert_eq!(value, None);
+
+        let value = map.get_mut(10);
+        assert_eq!(value, &mut 4);
+        *value = 2;
+        assert_eq!(map.try_get_mut(10), Some(&mut 2));
+    }
+
+    #[test]
+    fn test_get_disjoint_mut() {
+        let mut map: SecondaryMap<usize, i32> = SecondaryMap::new();
+
+        let values = map.get_disjoint_mut([0, 1, 2]);
+        assert_eq!(values, Some([&mut 0, &mut 0, &mut 0]));
+        let values = values.unwrap();
+        *values[0] = 1;
+        *values[1] = 2;
+        *values[2] = 3;
+        assert_eq!(
+            map.get_disjoint_mut([0, 1, 2]),
+            Some([&mut 1, &mut 2, &mut 3])
+        );
+
+        let values = map.get_disjoint_mut([0, 1, 0]);
+        assert_eq!(values, None);
+    }
+
+    #[test]
+    fn test_swap() {
+        let mut map: SecondaryMap<usize, i32> = SecondaryMap::new();
+        map[0] = 0x10;
+        map[1] = 0x11;
+        map[3] = 0x13;
+
+        map.swap(0, 1);
+        assert_eq!(map[0], 0x11);
+        assert_eq!(map[1], 0x10);
+
+        map.swap(10, 3);
+        assert_eq!(map[3], 0);
+        assert_eq!(map[10], 0x13);
     }
 }

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -34,7 +34,7 @@
 //! // Graph operations that modify the keys use callbacks to update the weights.
 //! graph.set_num_ports(node, 1, 3, |old, new| {if let Some(new) = new {port_weights.swap(old, new);}});
 //!
-//! // The map do not track item removals, but the user can shrink the map manually.
+//! // The map does not track item removals, but the user can shrink the map manually.
 //! graph.remove_node(node);
 //! node_weights.shrink_to(graph.node_count());
 //! port_weights.shrink_to(graph.port_count());

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -1,3 +1,41 @@
+//! A graph component that encodes node and port weights. For more complex
+//! scenarios, it is recommended to use a [`SecondaryMap`].
+//!
+//! This is a simple wrapper around two [`SecondaryMap`] containers. It does not
+//! keep track of key validity, and returns default values for missing keys. It
+//! is intended to be used alongside [`PortGraph`].
+//!
+//! # Example
+//!
+//! ```
+//! # use portgraph::{PortGraph, NodeIndex, PortIndex};
+//! # use portgraph::weights::Weights;
+//!
+//! let mut graph = PortGraph::new();
+//! let mut weights = Weights::<usize, isize>::new();
+//!
+//! // The weights must be set manually.
+//! let node = graph.add_node(2, 2);
+//! let [in0, in1, ..] = graph.inputs(node).collect::<Vec<_>>()[..] else { unreachable!() };
+//! let [out0, out1, ..] = graph.outputs(node).collect::<Vec<_>>()[..] else { unreachable!() };
+//! weights[node] = 42;
+//! weights[in1] = 2;
+//! weights[out0] = -1;
+//! weights[out1] = -2;
+//!
+//! /// Unset weights return the default value.
+//! assert_eq!(weights[in0], 0);
+//!
+//! // Graph operations that modify the keys use callbacks to update the weights.
+//! graph.set_num_ports(node, 1, 3, |old, new| {if let Some(new) = new {weights.ports.swap(old, new);}});
+//!
+//! // The map do not track item removals, but the user can shrink the map manually.
+//! graph.remove_node(node);
+//! weights.nodes.shrink_to(graph.node_count());
+//! weights.ports.shrink_to(graph.port_count());
+//!
+//! ```
+
 use std::ops::{Index, IndexMut};
 
 use crate::{NodeIndex, PortIndex, SecondaryMap};
@@ -6,7 +44,9 @@ use crate::{NodeIndex, PortIndex, SecondaryMap};
 /// Based on two [`SecondaryMap`] containers.
 #[derive(Debug, Clone)]
 pub struct Weights<N, P> {
+    /// Node weights.
     pub nodes: SecondaryMap<NodeIndex, N>,
+    /// Port weights.
     pub ports: SecondaryMap<PortIndex, P>,
 }
 
@@ -91,5 +131,26 @@ where
 {
     fn index_mut(&mut self, key: PortIndex) -> &mut Self::Output {
         &mut self.ports[key]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_weights() {
+        let mut weights = Weights::<usize, isize>::new();
+        let node = NodeIndex::new(0);
+        let port = PortIndex::new(0);
+
+        assert_eq!(weights[node], 0);
+        assert_eq!(weights[port], 0);
+
+        weights[node] = 42;
+        weights[port] = -1;
+
+        assert_eq!(weights[node], 42);
+        assert_eq!(weights[port], -1);
     }
 }

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -29,7 +29,7 @@
 //! // Graph operations that modify the keys use callbacks to update the weights.
 //! graph.set_num_ports(node, 1, 3, |old, new| {if let Some(new) = new {weights.ports.swap(old, new);}});
 //!
-//! // The map do not track item removals, but the user can shrink the map manually.
+//! // The map does not track item removals, but the user can shrink the map manually.
 //! graph.remove_node(node);
 //! weights.nodes.shrink_to(graph.node_count());
 //! weights.ports.shrink_to(graph.port_count());


### PR DESCRIPTION
Adds tests and docs to `secondary_map`, `weights`, and `hierarchy`.

Changes:
### secondary_map
- Adds `shrink_to` method
- Fixes UB in `get_disjoint_mut`. Thankfully miri caught it (the test was showing weird behaviour).
- Fix: `ensures_capacity` was a no-op.

### hierarchy
- Adds `remove`, `is_root`, and `shrink_to` methods
- Fixes `detach_children` not updating part of the node info.