### PR TITLE
Hierarchy fixes and docs

### DIFF
--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -1,3 +1,54 @@
+//! Hierarchical structure on top of a [`PortGraph`]. This is a separate
+//! relation from the graph's adjacency.
+//!
+//! The nodes form a forest, with each node having at most a single parent, and
+//! any number of children. Cycles are not allowed.
+//!
+//! This map does not allocate any memory until a value is modified. It is
+//! intended to be used alongside [`PortGraph`], as it does not keep track of
+//! key validity.
+//!
+//! [`PortGraph`]: crate::portgraph::PortGraph
+//!
+//! # Example
+//!
+//! ```
+//! # use portgraph::{PortGraph, NodeIndex, PortIndex};
+//! # use portgraph::hierarchy::Hierarchy;
+//! let mut graph = PortGraph::new();
+//! let mut hierarchy = Hierarchy::new();
+//!
+//! let parent = graph.add_node(0, 0);
+//! assert!(hierarchy.is_root(parent));
+//! assert_eq!(hierarchy.child_count(parent), 0);
+//!
+//! // Add some children.
+//! let child_0 = graph.add_node(0, 0);
+//! let child_1 = graph.add_node(0, 0);
+//! hierarchy.attach_first(child_1, parent).unwrap();
+//! hierarchy.attach_before(child_0, child_1).unwrap();
+//!
+//! assert_eq!(hierarchy.child_count(parent), 2);
+//! assert_eq!(hierarchy.children(parent).collect::<Vec<_>>(), vec![child_0, child_1]);
+//!
+//! assert_eq!(hierarchy.parent(child_0), Some(parent));
+//! assert_eq!(hierarchy.prev(child_0), None);
+//! assert_eq!(hierarchy.next(child_0), Some(child_1));
+//!
+//! // Modifications to the graph must be manually propagated to the hierarchy.
+//! graph.remove_node(parent);
+//! hierarchy.remove(parent);
+//!
+//! assert!(hierarchy.is_root(child_0));
+//! assert!(hierarchy.is_root(child_1));
+//! assert_eq!(hierarchy.next(child_0), None);
+//!
+//! graph.compact_nodes(|old, new| {
+//!     hierarchy.rekey(old, new);
+//! });
+//! hierarchy.shrink_to(graph.node_count());
+//! ```
+
 use std::iter::FusedIterator;
 use std::mem::{replace, take};
 use thiserror::Error;
@@ -130,7 +181,7 @@ impl Hierarchy {
         }
 
         let Some(parent) = self.get(before).parent else {
-            return Err(AttachError::RelativeToRoot);
+            return Err(AttachError::RootSibling);
         };
 
         if !self.cycle_check(node, parent) {
@@ -171,7 +222,7 @@ impl Hierarchy {
         }
 
         let Some(parent) = self.get(after).parent else {
-            return Err(AttachError::RelativeToRoot);
+            return Err(AttachError::RootSibling);
         };
 
         if !self.cycle_check(node, parent) {
@@ -246,6 +297,7 @@ impl Hierarchy {
 
         node_data.children_count = 0;
         let mut child_next = node_data.children[0];
+        node_data.children = [None, None];
 
         while let Some(child) = child_next {
             let child_data = self.get_mut(child);
@@ -255,10 +307,23 @@ impl Hierarchy {
         }
     }
 
+    /// Removes a node from the hierarchy, detaching it from its parent and
+    /// detaching all its children.
+    pub fn remove(&mut self, node: NodeIndex) {
+        self.detach_children(node);
+        self.detach(node);
+    }
+
     /// Returns a node's parent or `None` if it is a root.
     #[inline]
     pub fn parent(&self, node: NodeIndex) -> Option<NodeIndex> {
         self.get(node).parent
+    }
+
+    /// Returns whether a node is a root.
+    #[inline]
+    pub fn is_root(&self, node: NodeIndex) -> bool {
+        self.parent(node).is_none()
     }
 
     /// Returns a node's first child, if any.
@@ -340,6 +405,7 @@ impl Hierarchy {
         }
 
         *self.get_mut(new) = node_data;
+        *self.get_mut(old) = NodeData::default();
     }
 
     /// Reserves enough capacity to fit a maximum node index without reallocating.
@@ -348,7 +414,16 @@ impl Hierarchy {
         self.data.ensure_capacity(capacity);
     }
 
-    // TODO: API to shrink
+    /// Reduces the capacity of the structure to `capacity`.
+    /// Nodes with index higher than `capacity` are disconnected.
+    ///
+    /// Does nothing when the capacity of the secondary map is already lower.
+    pub fn shrink_to(&mut self, capacity: usize) {
+        for node in (capacity..self.data.capacity()).rev() {
+            self.remove(NodeIndex::new(node));
+        }
+        self.data.shrink_to(capacity);
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -359,7 +434,7 @@ struct NodeData {
     children_count: u32,
     /// The parent of a node, if any.
     parent: Option<NodeIndex>,
-    /// The sibilings of a node, if any.
+    /// The siblings of a node, if any.
     siblings: [Option<NodeIndex>; 2],
 }
 
@@ -431,12 +506,207 @@ impl<'a> ExactSizeIterator for Children<'a> {
 
 impl<'a> FusedIterator for Children<'a> {}
 
+/// Error produced when trying to attach nodes in the Hierarchy.
 #[derive(Debug, Clone, Error)]
 pub enum AttachError {
+    /// The node is already attached to a parent.
     #[error("the node is already attached")]
     AlreadyAttached,
-    #[error("can not attach relative to a root node")]
-    RelativeToRoot,
+    /// The target node is a root node, and cannot have siblings.
+    #[error("Can not attach a sibling to a root node")]
+    RootSibling,
+    /// The relation would introduce a cycle.
     #[error("attaching the node would introduce a cycle")]
     Cycle,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::PortGraph;
+
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        let mut hierarchy = Hierarchy::new();
+        let root = NodeIndex::new(4);
+
+        assert_eq!(hierarchy.child_count(root), 0);
+        assert_eq!(hierarchy.parent(root), None);
+        assert_eq!(hierarchy.first(root), None);
+        assert_eq!(hierarchy.last(root), None);
+        assert_eq!(hierarchy.next(root), None);
+        assert_eq!(hierarchy.prev(root), None);
+
+        let child0 = NodeIndex::new(0);
+        let child1 = NodeIndex::new(1);
+        let child2 = NodeIndex::new(2);
+        let children = [child0, child1, child2];
+        hierarchy.attach_first(child0, root).unwrap();
+        hierarchy.attach_last(child2, root).unwrap();
+        hierarchy.attach_after(child1, child0).unwrap();
+
+        assert!(hierarchy.attach_first(root, child2).is_err());
+        assert!(hierarchy.attach_first(child2, root).is_err());
+
+        assert_eq!(hierarchy.child_count(root), 3);
+        assert_eq!(
+            hierarchy.children(root).collect::<Vec<_>>(),
+            vec![child0, child1, child2]
+        );
+        assert_eq!(hierarchy.parent(root), None);
+        assert_eq!(hierarchy.first(root), Some(child0));
+        assert_eq!(hierarchy.last(root), Some(child2));
+        assert_eq!(hierarchy.next(root), None);
+        assert_eq!(hierarchy.prev(root), None);
+
+        for child in children {
+            assert_eq!(hierarchy.parent(child), Some(root));
+            assert_eq!(hierarchy.child_count(child), 0);
+        }
+        assert_eq!(hierarchy.prev(child0), None);
+        assert_eq!(hierarchy.next(child0), Some(child1));
+        assert_eq!(hierarchy.prev(child1), Some(child0));
+        assert_eq!(hierarchy.next(child1), Some(child2));
+        assert_eq!(hierarchy.prev(child2), Some(child1));
+        assert_eq!(hierarchy.next(child2), None);
+    }
+
+    #[test]
+    fn test_detach() {
+        let mut hierarchy = Hierarchy::new();
+        let root = NodeIndex::new(4);
+
+        let child0 = NodeIndex::new(0);
+        let child1 = NodeIndex::new(1);
+        let child2 = NodeIndex::new(2);
+        hierarchy.attach_last(child2, root).unwrap();
+        hierarchy.attach_before(child1, child2).unwrap();
+        hierarchy.attach_before(child0, child1).unwrap();
+
+        assert_eq!(
+            hierarchy.children(root).collect::<Vec<_>>(),
+            vec![child0, child1, child2]
+        );
+
+        hierarchy.detach(child1).unwrap();
+
+        assert_eq!(
+            hierarchy.children(root).collect::<Vec<_>>(),
+            vec![child0, child2]
+        );
+
+        assert_eq!(hierarchy.prev(child0), None);
+        assert_eq!(hierarchy.next(child0), Some(child2));
+        assert_eq!(hierarchy.prev(child2), Some(child0));
+        assert_eq!(hierarchy.next(child2), None);
+
+        assert_eq!(hierarchy.parent(child1), None);
+        assert_eq!(hierarchy.prev(child1), None);
+        assert_eq!(hierarchy.next(child1), None);
+
+        hierarchy.detach_children(root);
+
+        assert_eq!(hierarchy.first(root), None);
+        assert_eq!(hierarchy.last(root), None);
+        assert_eq!(hierarchy.children(root).collect::<Vec<_>>(), vec![]);
+        for child in [child0, child2] {
+            assert_eq!(hierarchy.parent(child), None);
+            assert_eq!(hierarchy.prev(child), None);
+            assert_eq!(hierarchy.next(child), None);
+        }
+    }
+
+    #[test]
+    fn test_rekey() {
+        let mut hierarchy = Hierarchy::new();
+        let root = NodeIndex::new(4);
+
+        let child0 = NodeIndex::new(0);
+        let child1 = NodeIndex::new(1);
+        let child2 = NodeIndex::new(2);
+        hierarchy.attach_last(child2, root).unwrap();
+        hierarchy.attach_before(child1, child2).unwrap();
+        hierarchy.attach_before(child0, child1).unwrap();
+
+        assert_eq!(
+            hierarchy.children(root).collect::<Vec<_>>(),
+            vec![child0, child1, child2]
+        );
+
+        let grandchild = NodeIndex::new(42);
+        hierarchy.attach_first(grandchild, child1).unwrap();
+
+        assert_eq!(
+            hierarchy.children(root).collect::<Vec<_>>(),
+            vec![child0, child1, child2]
+        );
+        assert_eq!(
+            hierarchy.children(child1).collect::<Vec<_>>(),
+            vec![grandchild]
+        );
+
+        let new_child1 = NodeIndex::new(8);
+        hierarchy.rekey(child1, new_child1);
+
+        assert_eq!(
+            hierarchy.children(root).collect::<Vec<_>>(),
+            vec![child0, new_child1, child2]
+        );
+        assert_eq!(
+            hierarchy.children(new_child1).collect::<Vec<_>>(),
+            vec![grandchild]
+        );
+        assert_eq!(hierarchy.parent(new_child1), Some(root));
+        assert_eq!(hierarchy.parent(grandchild), Some(new_child1));
+
+        assert_eq!(hierarchy.next(child0), Some(new_child1));
+        assert_eq!(hierarchy.next(new_child1), Some(child2));
+        assert_eq!(hierarchy.prev(new_child1), Some(child0));
+        assert_eq!(hierarchy.prev(child2), Some(new_child1));
+
+        hierarchy.remove(new_child1);
+        assert_eq!(
+            hierarchy.children(root).collect::<Vec<_>>(),
+            vec![child0, child2]
+        );
+        assert!(hierarchy.is_root(grandchild));
+    }
+
+    #[test]
+    fn test_graph_compact() {
+        let mut graph = PortGraph::new();
+        let mut hierarchy = Hierarchy::new();
+
+        let parent = graph.add_node(0, 0);
+        let mut child_0 = graph.add_node(0, 0);
+        let mut child_1 = graph.add_node(0, 0);
+        hierarchy.attach_first(child_1, parent).unwrap();
+        hierarchy.attach_before(child_0, child_1).unwrap();
+
+        // Modifications to the graph must be manually propagated to the hierarchy.
+        graph.remove_node(parent);
+        hierarchy.remove(parent);
+
+        assert!(hierarchy.is_root(child_0));
+        assert!(hierarchy.is_root(child_1));
+        assert_eq!(hierarchy.next(child_0), None);
+
+        hierarchy.attach_first(child_1, child_0).unwrap();
+
+        graph.compact_nodes(|old, new| {
+            hierarchy.rekey(old, new);
+            if old == child_0 {
+                child_0 = new;
+            } else if old == child_1 {
+                child_1 = new;
+            }
+        });
+
+        hierarchy.shrink_to(graph.node_count());
+
+        assert!(hierarchy.is_root(child_0));
+        assert_eq!(hierarchy.first(child_0), Some(child_1));
+        assert_eq!(hierarchy.parent(child_1), Some(child_0));
+    }
 }


### PR DESCRIPTION
Fixes a bug in `detach_children`, and adds `is_root`, `remove` and `shrink_to` methods.