### PR TITLE
Change default dot edge style

### DIFF
--- a/src/dot.rs
+++ b/src/dot.rs
@@ -150,8 +150,8 @@ mod tests {
 0 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="2" cellpadding="1">0</td><td port="in1" align="text" colspan="2" cellpadding="1">1</td><td port="in2" align="text" colspan="2" cellpadding="1">2</td></tr><tr><td align="text" border="0" colspan="6">0</td></tr><tr><td port="out0" align="text" colspan="3" cellpadding="1">0</td><td port="out1" align="text" colspan="3" cellpadding="1">1</td></tr></table>>]
 1 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="1" cellpadding="1">0</td></tr><tr><td align="text" border="0" colspan="1">1</td></tr></table>>]
 2 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="1" cellpadding="1">0</td></tr><tr><td align="text" border="0" colspan="1">2</td></tr></table>>]
-0:out0 -> 1:in0 [style=None]
-0:out1 -> 2:in0 [style=None]
+0:out0 -> 1:in0 [style=""]
+0:out1 -> 2:in0 [style=""]
 }
 "#;
         assert_eq!(dot, expected);
@@ -186,8 +186,8 @@ mod tests {
 0 [shape=plain label=<<table border="1"><tr><td align="text" border="0" colspan="2">node1</td></tr><tr><td port="out0" align="text" colspan="1" cellpadding="1">0: out 0</td><td port="out1" align="text" colspan="1" cellpadding="1">1: out 1</td></tr></table>>]
 1 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="1" cellpadding="1">0: in 0</td></tr><tr><td align="text" border="0" colspan="1">node2</td></tr></table>>]
 2 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="1" cellpadding="1">0: in 0</td></tr><tr><td align="text" border="0" colspan="1">node3</td></tr></table>>]
-0:out0 -> 1:in0 [style=None]
-0:out1 -> 2:in0 [style=None]
+0:out0 -> 1:in0 [style=""]
+0:out1 -> 2:in0 [style=""]
 }
 "#;
         assert_eq!(dot, expected);

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -122,9 +122,9 @@ fn get_edge_dot(
     let to_port = graph.port_link(from_port)?;
     let to_node = graph.port_node(to_port).expect("missing node");
     let to_offset = graph.port_offset(to_port).expect("missing port");
-    let edge_style = ports(from_port).1.unwrap_or("None".to_string());
+    let edge_style = ports(from_port).1.unwrap_or_default();
     Some(format!(
-        "{}:out{} -> {}:in{} [style={edge_style}]\n",
+        "{}:out{} -> {}:in{} [style=\"{edge_style}\"]\n",
         from_node.index(),
         from_offset,
         to_node.index(),


### PR DESCRIPTION
Closes #17 

I've removed the `None` for edge style, as suggested in https://github.com/CQCL/portgraph/issues/17.

From the [dot docs](https://graphviz.org/docs/attr-types/style/), it seems the style should be in quotes, so I've also added that, made my change easier.