### PR TITLE
Better names for the CI steps, update toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: default
-          toolchain: stable
           components: rustfmt, clippy
-          override: true
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v0
@@ -42,11 +39,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
           components: miri
       - name: Run miri
         run: cargo miri test
@@ -67,25 +61,27 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - id: toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
+      - name: Configure default rust toolchain
+        run: rustup override set ${{steps.toolchain.outputs.name}}
       - uses: Swatinem/rust-cache@v2
         if: ${{ matrix.cache }}
         with:
           prefix-key: v0-rust-${{ matrix.rust }}
-      - name: Build
-        run: |
-          cargo build --verbose --no-default-features
-          cargo build --verbose --all-features
-      - name: Tests
-        run: |
-          cargo test --verbose --no-default-features
-          cargo test --verbose --all-features
-      - name: Build benchmarks
+      - name: Build with no features
+        run: cargo build --verbose --no-default-features
+      - name: Build with all features
+        run: cargo build --verbose --all-features
+      - name: Tests with no features
+        run: cargo test --verbose --no-default-features
+      - name: Tests with all features
+        run: cargo test --verbose --all-features
+      - name: Build benchmarks with no features
         if: ${{ matrix.bench }}
-        run: |
-          cargo bench --verbose --no-run --no-default-features
-          cargo bench --verbose --no-run --all-features
+        run: cargo bench --verbose --no-run --no-default-features
+      - name: Build benchmarks with all features
+        if: ${{ matrix.bench }}
+        run: cargo bench --verbose --no-run --all-features


### PR DESCRIPTION
- Replaces [actions-rs/toolchain](http://github.com/actions-rs/toolchain) with [dtolnay/rust-toolchain](http://github.com/dtolnay/rust-toolchain), since the former is not being mantained and was throwing deprecation warnings.

- Splits the building and testing steps to differentiate when we an error occurs with `--no-default-features` vs `--all-features`.