### PR TITLE
Add a couple helper methods

### DIFF
--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -397,6 +397,12 @@ impl Hierarchy {
         self.get(node).children_count as usize
     }
 
+    /// Returns whether a node has any children.
+    #[inline]
+    pub fn has_children(&self, node: NodeIndex) -> bool {
+        self.child_count(node) > 0
+    }
+
     /// Changes the index of a node from `old` to `new`.
     ///
     /// # Panics

--- a/src/portgraph.rs
+++ b/src/portgraph.rs
@@ -1445,8 +1445,8 @@ impl<'a> Iterator for Ports<'a> {
     }
 }
 
-/// Iterator over the port offsets of a node.
-/// See [`PortGraph::input_offsets`], [`PortGraph::output_offsets`], and [`PortGraph::all_offsets`].
+/// Iterator over the port offsets of a node. See [`PortGraph::input_offsets`],
+/// [`PortGraph::output_offsets`], and [`PortGraph::all_port_offsets`].
 #[derive(Clone)]
 pub struct NodePortOffsets {
     incoming: Range<u16>,


### PR DESCRIPTION
- Adds a `has_children` method to the hierarchy.
- Adds a Neighbours iterator to query the neighbour nodes directly.
- Adds an NodePortOffsets iterator, useful when using the methods introduced in #20