### PR TITLE
Adds filter predicates to toposort

### DIFF
--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -6,4 +6,4 @@ mod toposort;
 
 pub use dominators::{dominators, DominatorTree};
 pub use post_order::{postorder, PostOrder};
-pub use toposort::{toposort, TopoSort};
+pub use toposort::{toposort, toposort_filtered, TopoSort};

--- a/src/algorithms/toposort.rs
+++ b/src/algorithms/toposort.rs
@@ -4,6 +4,9 @@ use std::{collections::VecDeque, iter::FusedIterator};
 
 /// Returns an iterator over a [`PortGraph`] in topological order.
 ///
+/// Optimized for full graph traversal, i.e. when all nodes are reachable from the source nodes.
+/// It uses O(n) memory, where n is the number of ports in the graph.
+///
 /// Implements [Kahn's algorithm](https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm).
 ///
 /// # Example
@@ -24,7 +27,57 @@ pub fn toposort(
     source: impl IntoIterator<Item = NodeIndex>,
     direction: Direction,
 ) -> TopoSort {
-    TopoSort::new(graph, source, direction)
+    TopoSort::new(graph, source, direction, None, None)
+}
+
+/// Returns an iterator over a [`PortGraph`] in topological order, filtering the
+/// nodes and ports to consider.
+///
+/// If the filter closures return false for a node or port, it is skipped.
+///
+/// Optimized for full graph traversal, i.e. when all nodes are reachable from the source nodes.
+/// It uses O(n) memory, where n is the number of ports in the graph.
+///
+/// Implements [Kahn's
+/// algorithm](https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm).
+///
+/// # Example
+///
+/// ```
+/// # use portgraph::{Direction, PortGraph};
+/// # use portgraph::algorithms::{toposort, toposort_filtered};
+/// let mut graph = PortGraph::new();
+/// let node_a = graph.add_node(2, 2);
+/// let node_b = graph.add_node(2, 2);
+/// let node_c = graph.add_node(2, 2);
+/// let node_d = graph.add_node(2, 2);
+/// graph.link_nodes(node_a, 0, node_b, 0).unwrap();
+/// graph.link_nodes(node_a, 1, node_c, 0).unwrap();
+///
+/// // Run a topological sort on the graph starting at node A.
+/// let topo = toposort_filtered(
+///     &graph,
+///     [node_a, node_d],
+///     Direction::Outgoing,
+///     |n| n != node_d,
+///     |p| Some(p) != graph.output(node_a, 1),
+/// );
+/// assert_eq!(topo.collect::<Vec<_>>(), [node_a, node_b]);
+/// ```
+pub fn toposort_filtered<'graph>(
+    graph: &'graph PortGraph,
+    source: impl IntoIterator<Item = NodeIndex>,
+    direction: Direction,
+    node_filter: impl FnMut(NodeIndex) -> bool + 'graph,
+    port_filter: impl FnMut(PortIndex) -> bool + 'graph,
+) -> TopoSort {
+    TopoSort::new(
+        graph,
+        source,
+        direction,
+        Some(Box::new(node_filter)),
+        Some(Box::new(port_filter)),
+    )
 }
 
 /// Iterator over a [`PortGraph`] in topological order.
@@ -42,6 +95,12 @@ pub struct TopoSort<'graph> {
     /// The number of nodes already returned from the iterator.
     /// This is used to calculate the upper bound for the iterator's `size_hint`.
     nodes_seen: usize,
+    /// A filter closure for the nodes to visit. If the closure returns false,
+    /// the node is skipped.
+    node_filter: Option<Box<dyn FnMut(NodeIndex) -> bool + 'graph>>,
+    /// A filter closure for the ports to visit. If the closure returns false,
+    /// the port is skipped.
+    port_filter: Option<Box<dyn FnMut(PortIndex) -> bool + 'graph>>,
 }
 
 impl<'graph> TopoSort<'graph> {
@@ -51,16 +110,33 @@ impl<'graph> TopoSort<'graph> {
         graph: &'graph PortGraph,
         source: impl IntoIterator<Item = NodeIndex>,
         direction: Direction,
+        mut node_filter: Option<Box<dyn FnMut(NodeIndex) -> bool + 'graph>>,
+        port_filter: Option<Box<dyn FnMut(PortIndex) -> bool + 'graph>>,
     ) -> Self {
         let mut remaining_ports = BitVec::with_capacity(graph.port_capacity());
         remaining_ports.resize(graph.port_capacity(), true);
 
+        let candidate_nodes: VecDeque<_> = if let Some(node_filter) = node_filter.as_mut() {
+            source.into_iter().filter(|&n| node_filter(n)).collect()
+        } else {
+            source.into_iter().collect()
+        };
+
+        // Mark all the candidate ports as visited, so we don't visit them again.
+        for node in candidate_nodes.iter() {
+            for port in graph.ports(*node, direction.reverse()) {
+                remaining_ports.set(port.index(), false);
+            }
+        }
+
         Self {
             graph,
             remaining_ports,
-            candidate_nodes: source.into_iter().collect(),
+            candidate_nodes,
             direction,
             nodes_seen: 0,
+            node_filter,
+            port_filter,
         }
     }
 
@@ -70,20 +146,46 @@ impl<'graph> TopoSort<'graph> {
         self.remaining_ports.iter_ones().map(PortIndex::new)
     }
 
-    /// Checks if a node is ready to be visited, i.e. it has been reached from
-    /// all its linked ports.
-    fn target_ready(&mut self, node: NodeIndex) -> bool {
+    /// Checks if a node becomes ready once it is visited from `from_port`, i.e.
+    /// it has been reached from all its linked ports.
+    fn becomes_ready(&mut self, node: NodeIndex, from_port: PortIndex) -> bool {
+        if self.ignore_node(node) {
+            return false;
+        }
         self.graph.ports(node, self.direction.reverse()).all(|p| {
-            if !self.remaining_ports[p.index()] {
+            if p == from_port {
+                // This port must have not been visited yet. Otherwise, the node
+                // would have been already been reported as ready and added to
+                // the candidate list.
+                self.remaining_ports[p.index()]
+            } else if !self.remaining_ports[p.index()] {
                 true
-            } else if self.graph.port_link(p).is_none() {
-                // If the port is not linked, mark it as visited.
+            } else if self.graph.port_link(p).is_none() || self.ignore_port(p) {
+                // If the port is not linked or should be ignored, mark it as visited.
                 self.remaining_ports.set(p.index(), false);
                 true
             } else {
                 false
             }
         })
+    }
+
+    /// Returns `true` if the node should be ignored.
+    #[inline]
+    fn ignore_node(&mut self, node: NodeIndex) -> bool {
+        !self
+            .node_filter
+            .as_mut()
+            .map_or(true, |filter| filter(node))
+    }
+
+    /// Returns `true` if the port should be ignored.
+    #[inline]
+    fn ignore_port(&mut self, port: PortIndex) -> bool {
+        !self
+            .port_filter
+            .as_mut()
+            .map_or(true, |filter| filter(port))
     }
 }
 
@@ -96,13 +198,17 @@ impl<'graph> Iterator for TopoSort<'graph> {
         for port in self.graph.ports(node, self.direction) {
             self.remaining_ports.set(port.index(), false);
 
+            if self.ignore_port(port) {
+                continue;
+            }
+
             if let Some(link) = self.graph.port_link(port) {
-                self.remaining_ports.set(link.index(), false);
                 let target = self.graph.port_node(link).unwrap();
 
-                if self.target_ready(target) {
+                if self.becomes_ready(target, link) {
                     self.candidate_nodes.push_back(target);
                 }
+                self.remaining_ports.set(link.index(), false);
             }
         }
 
@@ -123,20 +229,35 @@ impl<'graph> FusedIterator for TopoSort<'graph> {}
 
 #[cfg(test)]
 mod test {
-    use crate::{algorithms::toposort, Direction, PortGraph};
+    use super::*;
+
+    use crate::{Direction, PortGraph};
 
     #[test]
     fn small_toposort() {
         let mut graph = PortGraph::new();
         let node_a = graph.add_node(2, 3);
         let node_b = graph.add_node(3, 2);
+        let node_c = graph.add_node(3, 2);
+        let node_d = graph.add_node(3, 2);
 
         // Add two edges between node A and B
         graph.link_nodes(node_a, 0, node_b, 0).unwrap();
         graph.link_nodes(node_a, 1, node_b, 1).unwrap();
+        graph.link_nodes(node_b, 0, node_c, 0).unwrap();
+        graph.link_nodes(node_c, 0, node_d, 0).unwrap();
 
         // Run a topological sort on the graph starting at node A.
-        let topo = toposort(&graph, [node_a], Direction::Outgoing);
-        assert_eq!(topo.collect::<Vec<_>>(), [node_a, node_b]);
+        let topo = toposort(&graph, [node_a, node_d], Direction::Outgoing);
+        assert_eq!(topo.collect::<Vec<_>>(), [node_a, node_d, node_b, node_c]);
+
+        let topo_filtered = toposort_filtered(
+            &graph,
+            [node_a, node_d],
+            Direction::Outgoing,
+            |n| n != node_d,
+            |p| Some(p) != graph.output(node_b, 0),
+        );
+        assert_eq!(topo_filtered.collect::<Vec<_>>(), [node_a, node_b]);
     }
 }


### PR DESCRIPTION
Closes #29.

Also fixes a bug where nodes would be visited multiple times when one source was reachable from another.

As a future TODO (I'll open an issue), we should write an alternative implementation that's more performant when run on subsets of the graph. Currently we always create a bitvec with all the ports in the graph, which uses O(#ports) memory.