### PR TITLE
Add filtered versions of `dominators` and `postorder` algorithms

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -4,6 +4,6 @@ mod dominators;
 mod post_order;
 mod toposort;
 
-pub use dominators::{dominators, DominatorTree};
+pub use dominators::{dominators, dominators_filtered, DominatorTree};
 pub use post_order::{postorder, postorder_filtered, PostOrder};
 pub use toposort::{toposort, toposort_filtered, TopoSort};

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -5,5 +5,5 @@ mod post_order;
 mod toposort;
 
 pub use dominators::{dominators, DominatorTree};
-pub use post_order::{postorder, PostOrder};
+pub use post_order::{postorder, postorder_filtered, PostOrder};
 pub use toposort::{toposort, toposort_filtered, TopoSort};

--- a/src/algorithms/dominators.rs
+++ b/src/algorithms/dominators.rs
@@ -41,11 +41,14 @@ pub fn dominators(graph: &PortGraph, entry: NodeIndex, direction: Direction) -> 
 }
 
 /// Returns a dominator tree for a [`PortGraph`], where each node is dominated
-/// by its parent.
+/// by its parent, applying a filter to the nodes and ports.
+///
+/// If the filter predicate returns `false` for a node or port, it is ignored
+/// when computing the dominator tree.
 ///
 /// # Example
 ///
-/// The following example runs the dominator algorithm on the following branching graph:
+/// This example runs the dominator algorithm on the following branching graph:
 /// a ─┬> b ┐
 ///    │    ├─> c ─> e
 /// f ─┴> d ┴────────^

--- a/src/algorithms/post_order.rs
+++ b/src/algorithms/post_order.rs
@@ -2,7 +2,7 @@ use std::iter::FusedIterator;
 
 use bitvec::vec::BitVec;
 
-use crate::{Direction, NodeIndex, PortGraph};
+use crate::{Direction, NodeIndex, PortGraph, PortIndex};
 
 /// Returns an iterator doing a post-order traversal of a spanning tree in a
 /// [`PortGraph`].
@@ -53,7 +53,83 @@ pub fn postorder(
     source: impl IntoIterator<Item = NodeIndex>,
     direction: Direction,
 ) -> PostOrder {
-    PostOrder::new(graph, source, direction)
+    PostOrder::new(graph, source, direction, None, None)
+}
+
+/// Returns an iterator doing a post-order traversal of a spanning tree in a
+/// [`PortGraph`], applying a filter to the nodes and ports. No filtered nodes
+/// are returned, and neither are any nodes only accessible via filtered nodes
+/// or filtered ports.
+///
+/// If the filter closures return false for a node or port, it is skipped.
+///
+/// The iterator will visit all nodes reachable from the `source`s, returning
+/// the nodes in each subtree following the port order before returning the
+/// root.
+///
+/// # Example
+///
+/// We create the following tree:
+///
+/// a ━▸ b ┳━▸ c
+///        ┣━▸ d ━▸ e
+///        ┗━▸ f
+///
+/// And traverse it in post-order:
+///
+/// ```
+/// # use portgraph::{algorithms::postorder_filtered, Direction, PortGraph};
+/// let mut graph = PortGraph::new();
+///
+/// let a = graph.add_node(0, 1);
+/// let b = graph.add_node(1, 3);
+/// let c = graph.add_node(1, 1);
+/// let d = graph.add_node(1, 1);
+/// let e = graph.add_node(1, 0);
+/// let f = graph.add_node(1, 0);
+///
+/// graph.link_nodes(a, 0, b, 0).unwrap();
+/// graph.link_nodes(b, 0, c, 0).unwrap();
+/// graph.link_nodes(b, 1, d, 0).unwrap();
+/// graph.link_nodes(b, 2, f, 0).unwrap();
+/// graph.link_nodes(d, 0, e, 0).unwrap();
+///
+/// // Forward starting from `a`
+/// let order = postorder_filtered(
+///     &graph,
+///     vec![a],
+///     Direction::Outgoing,
+///     |_| true,
+///     |_node, port| ![graph.output(b, 2), graph.input(d, 0)].contains(&Some(port))
+/// ).collect::<Vec<_>>();
+/// assert_eq!(order, vec![c, b, a]);
+///
+/// // Reverse starting from `e`
+/// let order = postorder_filtered(
+///     &graph,
+///     vec![e],
+///     Direction::Incoming,
+///     |n| n != b,
+///     |_,_| true
+/// ).collect::<Vec<_>>();
+/// assert_eq!(order, vec![d, e]);
+/// ```
+///
+///
+pub fn postorder_filtered<'graph>(
+    graph: &'graph PortGraph,
+    source: impl IntoIterator<Item = NodeIndex>,
+    direction: Direction,
+    node_filter: impl FnMut(NodeIndex) -> bool + 'graph,
+    port_filter: impl FnMut(NodeIndex, PortIndex) -> bool + 'graph,
+) -> PostOrder {
+    PostOrder::new(
+        graph,
+        source,
+        direction,
+        Some(Box::new(node_filter)),
+        Some(Box::new(port_filter)),
+    )
 }
 
 /// Iterator over a [`PortGraph`] in post-order.
@@ -65,6 +141,15 @@ pub struct PostOrder<'graph> {
     visited: BitVec,
     finished: BitVec,
     direction: Direction,
+    /// The number of nodes already returned from the iterator.
+    /// This is used to calculate the upper bound for the iterator's `size_hint`.
+    nodes_seen: usize,
+    /// A filter closure for the nodes to visit. If the closure returns false,
+    /// the node is skipped.
+    node_filter: Option<Box<dyn FnMut(NodeIndex) -> bool + 'graph>>,
+    /// A filter closure for the ports to visit. If the closure returns false,
+    /// the port is skipped.
+    port_filter: Option<Box<dyn FnMut(NodeIndex, PortIndex) -> bool + 'graph>>,
 }
 
 impl<'graph> PostOrder<'graph> {
@@ -72,13 +157,19 @@ impl<'graph> PostOrder<'graph> {
         graph: &'graph PortGraph,
         source: impl IntoIterator<Item = NodeIndex>,
         direction: Direction,
+        mut node_filter: Option<Box<dyn FnMut(NodeIndex) -> bool + 'graph>>,
+        port_filter: Option<Box<dyn FnMut(NodeIndex, PortIndex) -> bool + 'graph>>,
     ) -> Self {
         let mut visited = BitVec::with_capacity(graph.node_capacity());
         visited.resize(graph.node_capacity(), false);
         let mut finished = BitVec::with_capacity(graph.node_capacity());
         finished.resize(graph.node_capacity(), false);
 
-        let mut source: Vec<_> = source.into_iter().collect();
+        let mut source: Vec<_> = if let Some(node_filter) = node_filter.as_mut() {
+            source.into_iter().filter(|&n| node_filter(n)).collect()
+        } else {
+            source.into_iter().collect()
+        };
         source.reverse();
 
         Self {
@@ -87,7 +178,28 @@ impl<'graph> PostOrder<'graph> {
             visited,
             finished,
             direction,
+            nodes_seen: 0,
+            node_filter,
+            port_filter,
         }
+    }
+
+    /// Returns `true` if the node should be ignored.
+    #[inline]
+    fn ignore_node(&mut self, node: NodeIndex) -> bool {
+        !self
+            .node_filter
+            .as_mut()
+            .map_or(true, |filter| filter(node))
+    }
+
+    /// Returns `true` if the port should be ignored.
+    #[inline]
+    fn ignore_port(&mut self, node: NodeIndex, port: PortIndex) -> bool {
+        !self
+            .port_filter
+            .as_mut()
+            .map_or(true, |filter| filter(node, port))
     }
 }
 
@@ -100,11 +212,18 @@ impl<'graph> Iterator for PostOrder<'graph> {
                 // The node is visited for the first time. We leave the node on the stack and push
                 // all of its neighbours in the traversal direction.
                 for port in self.graph.ports(next, self.direction).rev() {
+                    if self.ignore_port(next, port) {
+                        continue;
+                    }
+
                     let Some(link) = self.graph.port_link(port) else {
                         continue;
                     };
-
                     let link_node = self.graph.port_node(link).unwrap();
+
+                    if self.ignore_node(link_node) || self.ignore_port(link_node, link) {
+                        continue;
+                    }
 
                     if !self.visited[link_node.index()] {
                         self.stack.push(link_node);
@@ -114,6 +233,7 @@ impl<'graph> Iterator for PostOrder<'graph> {
                 // The node is visited for the second time. We remove it from the stack and return
                 // as the next node in the traversal.
                 self.stack.pop();
+                self.nodes_seen += 1;
                 return Some(next);
             } else {
                 // The node has already been visited at least twice, so we ignore it.
@@ -122,6 +242,11 @@ impl<'graph> Iterator for PostOrder<'graph> {
         }
 
         None
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.graph.node_count() - self.nodes_seen))
     }
 }
 
@@ -214,5 +339,46 @@ mod tests {
         // Backwards starting from `c`
         let order = postorder(&graph, vec![c], Direction::Incoming).collect::<Vec<_>>();
         assert_eq!(order, vec![a, d, b, c]);
+    }
+
+    #[test]
+    fn postorder_with_filters() {
+        let mut graph = PortGraph::new();
+        // a -> b -> c
+        //       \     \
+        //        \--2-----> d
+        let a = graph.add_node(0, 1);
+        let b = graph.add_node(1, 3);
+        let c = graph.add_node(1, 1);
+        let d = graph.add_node(3, 0);
+
+        graph.link_nodes(a, 0, b, 0).unwrap();
+        graph.link_nodes(b, 0, c, 0).unwrap();
+        graph.link_nodes(b, 1, d, 0).unwrap();
+        graph.link_nodes(c, 0, d, 1).unwrap();
+        graph.link_nodes(b, 2, d, 2).unwrap(); // Double link
+
+        // Completely node-filtered
+        let order =
+            postorder_filtered(&graph, vec![a], Direction::Outgoing, |_| false, |_, _| true)
+                .collect::<Vec<_>>();
+        assert_eq!(order, vec![]);
+
+        // Completely edge-filtered
+        let order =
+            postorder_filtered(&graph, vec![a], Direction::Outgoing, |_| true, |_, _| false)
+                .collect::<Vec<_>>();
+        assert_eq!(order, vec![a]);
+
+        // Backwards starting from `d`. Filtering one of the double links from `b`, and node `c`.
+        let order = postorder_filtered(
+            &graph,
+            vec![d],
+            Direction::Incoming,
+            |n| n != c,
+            |_, p| Some(p) != graph.output(b, 2),
+        )
+        .collect::<Vec<_>>();
+        assert_eq!(order, vec![a, b, d]);
     }
 }


### PR DESCRIPTION
Similar to #30.

- Moves `algorithms/mod.rs` to `algorithms.rs`.
- Breaking change: Adds a `NodeIndex` parameter to the port filter in `toposort_filtered`, to avoid unnecessary calls to `portgraph::port_node` while filtering.