### PR TITLE
Add port capacity to the nodes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,12 @@ impl std::fmt::Debug for PortIndex {
     }
 }
 
+impl Default for PortIndex {
+    fn default() -> Self {
+        PortIndex::new(0)
+    }
+}
+
 /// Error indicating a `NodeIndex`, `PortIndex`, or `Direction` is too large.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 #[error("the index {index} is too large.")]

--- a/src/portgraph.rs
+++ b/src/portgraph.rs
@@ -782,6 +782,7 @@ impl PortGraph {
     }
 
     /// Returns the allocated port capacity for a specific node.
+    ///
     /// Changes to the number of ports of the node will not reallocate
     /// until the number of ports exceeds this capacity.
     #[inline]

--- a/src/portgraph.rs
+++ b/src/portgraph.rs
@@ -111,9 +111,18 @@ impl PortGraph {
     /// assert!(g.contains_node(node));
     /// ```
     pub fn add_node(&mut self, incoming: usize, outgoing: usize) -> NodeIndex {
-        assert!(incoming <= NodeMeta::MAX_INCOMING);
-        assert!(outgoing <= NodeMeta::MAX_OUTGOING);
-        assert!(incoming + outgoing <= u16::MAX as usize);
+        assert!(
+            incoming <= NodeMeta::MAX_INCOMING,
+            "Incoming port count exceeds maximum."
+        );
+        assert!(
+            outgoing <= NodeMeta::MAX_OUTGOING,
+            "Outgoing port count exceeds maximum."
+        );
+        assert!(
+            incoming + outgoing <= u16::MAX as usize,
+            "Total port count exceeds maximum u16::MAX."
+        );
 
         let node = self.alloc_node();
         let node_meta = self.alloc_ports(node, incoming, outgoing, 0);
@@ -818,8 +827,14 @@ impl PortGraph {
     ) where
         F: FnMut(PortIndex, Option<PortIndex>),
     {
-        assert!(incoming < NodeMeta::MAX_INCOMING);
-        assert!(outgoing < NodeMeta::MAX_OUTGOING);
+        assert!(
+            incoming <= NodeMeta::MAX_INCOMING,
+            "Incoming port count exceeds maximum."
+        );
+        assert!(
+            outgoing <= NodeMeta::MAX_OUTGOING,
+            "Outgoing port count exceeds maximum."
+        );
 
         let new_total = incoming + outgoing;
 
@@ -873,8 +888,7 @@ impl PortGraph {
         self.node_meta[node.index()] = NodeEntry::Node(new_meta);
         self.free_ports(old_port_list, old_capacity);
 
-        self.port_count -= old_total;
-        self.port_count += new_total;
+        self.port_count = self.port_count - old_total + new_total;
     }
 
     /// Compacts the storage of nodes in the portgraph so that all nodes are stored consecutively.

--- a/src/portgraph.rs
+++ b/src/portgraph.rs
@@ -14,6 +14,7 @@ mod iter;
 
 use std::mem::{replace, take};
 use std::num::{NonZeroU16, NonZeroU32};
+use std::ops::Range;
 use thiserror::Error;
 
 use crate::{Direction, NodeIndex, PortIndex, PortOffset};
@@ -94,6 +95,10 @@ impl PortGraph {
 
     /// Adds a node to the portgraph with a given number of input and output ports.
     ///
+    /// # Panics
+    ///
+    /// Panics if the total number of ports exceeds `u16::MAX`.
+    ///
     /// # Example
     ///
     /// ```
@@ -106,19 +111,23 @@ impl PortGraph {
     /// assert!(g.contains_node(node));
     /// ```
     pub fn add_node(&mut self, incoming: usize, outgoing: usize) -> NodeIndex {
-        let node = self.alloc_node();
+        assert!(incoming <= NodeMeta::MAX_INCOMING);
+        assert!(outgoing <= NodeMeta::MAX_OUTGOING);
+        assert!(incoming + outgoing <= u16::MAX as usize);
 
-        let port_list = if incoming + outgoing > 0 {
-            Some(self.alloc_ports(node, incoming, outgoing))
+        let node = self.alloc_node();
+        let (port_list, capacity) = if incoming + outgoing > 0 {
+            self.alloc_ports(node, incoming, outgoing)
         } else {
-            None
+            (PortIndex::default(), 0)
         };
 
-        assert!(incoming < NodeMeta::MAX_INCOMING);
-        assert!(outgoing < NodeMeta::MAX_OUTGOING);
-
-        self.node_meta[node.index()] =
-            NodeEntry::Node(NodeMeta::new(port_list, incoming as u16, outgoing as u16));
+        self.node_meta[node.index()] = NodeEntry::Node(NodeMeta::new(
+            port_list,
+            incoming as u16,
+            outgoing as u16,
+            capacity,
+        ));
 
         self.node_count += 1;
         self.port_count += incoming + outgoing;
@@ -145,8 +154,17 @@ impl PortGraph {
         }
     }
 
+    /// Allocates a slab of ports. Returns the index of the first port, and the
+    /// number of ports in the slab.
+    ///
+    /// TODO: Over-allocate by a factor
     #[inline]
-    fn alloc_ports(&mut self, node: NodeIndex, incoming: usize, outgoing: usize) -> PortIndex {
+    fn alloc_ports(
+        &mut self,
+        node: NodeIndex,
+        incoming: usize,
+        outgoing: usize,
+    ) -> (PortIndex, u16) {
         let size = incoming + outgoing;
         let meta_incoming = PortEntry::Port(PortMeta::new(node, Direction::Incoming));
         let meta_outgoing = PortEntry::Port(PortMeta::new(node, Direction::Outgoing));
@@ -161,7 +179,7 @@ impl PortGraph {
                 self.port_meta[i..i + incoming].fill(meta_incoming);
                 self.port_link[i..i + size].fill(None);
 
-                port
+                (port, size as u16)
             }
             None => {
                 debug_assert_eq!(self.port_meta.len(), self.port_link.len());
@@ -173,7 +191,7 @@ impl PortGraph {
                 self.port_meta.resize(old_len + size, meta_outgoing);
                 self.port_link.resize(old_len + size, None);
 
-                port
+                (port, size as u16)
             }
         }
     }
@@ -209,9 +227,10 @@ impl PortGraph {
 
         self.node_count -= 1;
 
-        if let Some(port_list) = node_meta.port_list() {
-            let size = node_meta.incoming() as usize + node_meta.outgoing() as usize;
-            self.port_count -= size;
+        if node_meta.capacity() > 0 {
+            let port_list = node_meta.port_list();
+            let size = node_meta.capacity();
+            self.port_count -= node_meta.port_count();
 
             assert!(port_list.index() + size <= self.port_link.len());
             assert!(port_list.index() + size <= self.port_meta.len());
@@ -428,11 +447,7 @@ impl PortGraph {
             NodeEntry::Node(node_meta) => node_meta,
         };
 
-        let port_list = node_meta
-            .port_list()
-            .expect("port list can't be empty since it contains at least the given port");
-
-        let port_offset = port.index().wrapping_sub(port_list.index());
+        let port_offset = port.index().wrapping_sub(node_meta.port_list().index());
 
         match port_meta.direction() {
             Direction::Incoming => Some(PortOffset::new_incoming(port_offset)),
@@ -448,18 +463,8 @@ impl PortGraph {
     pub fn port_index(&self, node: NodeIndex, offset: PortOffset) -> Option<PortIndex> {
         let node_meta = self.node_meta_valid(node)?;
         let direction = offset.direction();
-        let mut offset: u16 = offset.index() as u16;
-        let bounds_check = if direction == Direction::Outgoing {
-            offset += node_meta.incoming();
-            offset < node_meta.incoming() + node_meta.outgoing()
-        } else {
-            offset < node_meta.incoming()
-        };
-        if !bounds_check {
-            return None;
-        }
-        let index = node_meta.port_list()?.0;
-        Some(PortIndex(index.saturating_add(offset as u32)))
+        let offset = offset.index();
+        node_meta.ports(direction).nth(offset).map(PortIndex::new)
     }
 
     /// Returns the port that the given `port` is linked to.
@@ -471,39 +476,21 @@ impl PortGraph {
 
     /// Iterates over all the ports of the `node` in the given `direction`.
     pub fn ports(&self, node: NodeIndex, direction: Direction) -> NodePorts {
-        let Some(node_meta) = self.node_meta_valid(node) else {
-            return NodePorts::default();
-        };
-
-        let Some(port_list) = node_meta.port_list() else {
-            return NodePorts::default();
-        };
-
-        match direction {
-            Direction::Incoming => NodePorts {
-                index: port_list.0,
-                length: node_meta.incoming() as usize,
+        match self.node_meta_valid(node) {
+            Some(node_meta) => NodePorts {
+                indices: node_meta.ports(direction),
             },
-            Direction::Outgoing => NodePorts {
-                index: port_list.0.saturating_add(node_meta.incoming() as u32),
-                length: node_meta.outgoing() as usize,
-            },
+            None => NodePorts::default(),
         }
     }
 
     /// Iterates over the input and output ports of the `node` in sequence.
     pub fn all_ports(&self, node: NodeIndex) -> NodePorts {
-        let Some(node_meta) = self.node_meta_valid(node) else {
-            return NodePorts::default();
-        };
-
-        let Some(port_list) = node_meta.port_list() else {
-            return NodePorts::default();
-        };
-
-        NodePorts {
-            index: port_list.0,
-            length: node_meta.incoming() as usize + node_meta.outgoing() as usize,
+        match self.node_meta_valid(node) {
+            Some(node_meta) => NodePorts {
+                indices: node_meta.all_ports(),
+            },
+            None => NodePorts::default(),
         }
     }
 
@@ -645,23 +632,8 @@ impl PortGraph {
         let Some(node_meta) = self.node_meta_valid(node) else {
             return NodeLinks([].iter());
         };
-
-        let Some(port_list) = node_meta.port_list() else {
-            return NodeLinks([].iter());
-        };
-
-        match direction {
-            Direction::Incoming => {
-                let start = port_list.index();
-                let stop = start + node_meta.incoming() as usize;
-                NodeLinks(self.port_link[start..stop].iter())
-            }
-            Direction::Outgoing => {
-                let start = port_list.index() + node_meta.incoming() as usize;
-                let stop = start + node_meta.outgoing() as usize;
-                NodeLinks(self.port_link[start..stop].iter())
-            }
-        }
+        let indices = node_meta.ports(direction);
+        NodeLinks(self.port_link[indices].iter())
     }
 
     /// Iterates over the input links of the `node`. Shorthand for [`PortGraph::links`].
@@ -682,14 +654,8 @@ impl PortGraph {
         let Some(node_meta) = self.node_meta_valid(node) else {
             return NodeLinks([].iter());
         };
-
-        let Some(port_list) = node_meta.port_list() else {
-            return NodeLinks([].iter());
-        };
-
-        let start = port_list.index();
-        let stop = start + node_meta.incoming() as usize + node_meta.outgoing() as usize;
-        NodeLinks(self.port_link[start..stop].iter())
+        let indices = node_meta.all_ports();
+        NodeLinks(self.port_link[indices].iter())
     }
 
     /// Iterates over neighbour nodes in the given `direction`.
@@ -813,6 +779,15 @@ impl PortGraph {
         self.port_meta.capacity()
     }
 
+    /// Returns the allocated port capacity for a specific node.
+    /// Changes to the number of ports of the node will not reallocate
+    /// until the number of ports exceeds this capacity.
+    #[inline]
+    pub fn node_port_capacity(&self, node: NodeIndex) -> usize {
+        self.node_meta_valid(node)
+            .map_or(0, |node_meta| node_meta.capacity())
+    }
+
     /// Reserves enough capacity to insert at least the given number of additional nodes and ports.
     ///
     /// This method does not take into account the length of the free list and might overallocate speculatively.
@@ -840,8 +815,6 @@ impl PortGraph {
     ) where
         F: FnMut(PortIndex, Option<PortIndex>),
     {
-        // TODO: Add port capacity and use a grow factor to avoid unnecessary reallocations.
-
         assert!(incoming < NodeMeta::MAX_INCOMING);
         assert!(outgoing < NodeMeta::MAX_OUTGOING);
 
@@ -850,17 +823,13 @@ impl PortGraph {
         let Some(node_meta) = self.node_meta_valid(node) else {return;};
         let old_incoming = node_meta.incoming() as usize;
         let old_outgoing = node_meta.outgoing() as usize;
+        let old_capacity = node_meta.capacity();
         let old_total = old_incoming + old_outgoing;
         let old_port_list = node_meta.port_list();
         if old_incoming == incoming && old_outgoing == outgoing {
+            // Nothing to do
             return;
         }
-        if old_incoming + old_outgoing == incoming + outgoing {
-            // Special case when we can avoid reallocations by rotating the ports in-place.
-            self.resize_ports_inplace(node, incoming, outgoing, rekey);
-            return;
-        }
-
         // Disconnect any port to be removed.
         for port in self
             .inputs(node)
@@ -871,40 +840,47 @@ impl PortGraph {
             rekey(port, None);
         }
 
-        let port_list = if incoming + outgoing > 0 {
-            let new_port_list = self.alloc_ports(node, incoming, outgoing);
-            if let Some(old_port_list) = old_port_list {
-                let incoming_rekeys = (0..old_incoming).zip(0..incoming);
-                let outgoing_rekeys = (old_incoming..old_total).zip(incoming..new_total);
-                for (old, new) in incoming_rekeys.chain(outgoing_rekeys) {
-                    let old_index = old_port_list.index() + old;
-                    let new_index = new_port_list.index() + new;
-                    let old_port = PortIndex::new(old_index);
-                    let new_port = PortIndex::new(new_index);
+        if 0 < new_total && new_total <= old_capacity {
+            // Special case when we can avoid reallocations by shifting the
+            // ports in the pre-allocated slab.
+            self.resize_ports_inplace(node, incoming, outgoing, rekey);
+            return;
+        }
+        let new_meta = if new_total > 0 {
+            // We need to allocate more space and copy the old ports.
+            let (new_port_list, new_capacity) = self.alloc_ports(node, incoming, outgoing);
 
-                    if let Some(link) = self.port_link[old_index] {
-                        self.port_link[link.index()] = Some(new_port);
-                    }
-                    self.port_link[new_index] = self.port_link[old_index].take();
-                    self.port_meta[new_index] = self.port_meta[old_index];
+            let incoming_rekeys = (0..old_incoming).zip(0..incoming);
+            let outgoing_rekeys = (old_incoming..old_total).zip(incoming..new_total);
+            for (old, new) in incoming_rekeys.chain(outgoing_rekeys) {
+                let old_index = old_port_list.index() + old;
+                let new_index = new_port_list.index() + new;
+                let old_port = PortIndex::new(old_index);
+                let new_port = PortIndex::new(new_index);
 
-                    rekey(old_port, Some(new_port));
+                if let Some(link) = self.port_link[old_index] {
+                    self.port_link[link.index()] = Some(new_port);
                 }
-                self.free_ports(old_port_list, old_incoming + old_outgoing);
+                self.port_link[new_index] = self.port_link[old_index].take();
+                self.port_meta[new_index] = self.port_meta[old_index];
+
+                rekey(old_port, Some(new_port));
             }
-            Some(new_port_list)
+            NodeMeta::new(
+                new_port_list,
+                incoming as u16,
+                outgoing as u16,
+                new_capacity,
+            )
         } else {
-            if let Some(plist) = old_port_list {
-                self.free_ports(plist, old_incoming + old_outgoing);
-            }
-            None
+            // All ports are dropped. We can release the port list.
+            NodeMeta::new(PortIndex::default(), 0, 0, 0)
         };
+        self.node_meta[node.index()] = NodeEntry::Node(new_meta);
+        self.free_ports(old_port_list, old_capacity);
 
-        self.node_meta[node.index()] =
-            NodeEntry::Node(NodeMeta::new(port_list, incoming as u16, outgoing as u16));
-
-        self.port_count -= old_incoming + old_outgoing;
-        self.port_count += incoming + outgoing;
+        self.port_count -= old_total;
+        self.port_count += new_total;
     }
 
     /// Compacts the storage of nodes in the portgraph so that all nodes are stored consecutively.
@@ -925,18 +901,9 @@ impl PortGraph {
                 return false;
             };
 
-            if let Some(port_list) = node_meta.port_list() {
-                let incoming = node_meta.incoming() as usize;
-                let outgoing = node_meta.outgoing() as usize;
-
-                for port in port_list.index()..port_list.index() + incoming {
-                    self.port_meta[port] =
-                        PortEntry::Port(PortMeta::new(new_node, Direction::Incoming));
-                }
-
-                for port in port_list.index() + incoming..port_list.index() + incoming + outgoing {
-                    self.port_meta[port] =
-                        PortEntry::Port(PortMeta::new(new_node, Direction::Outgoing));
+            for dir in Direction::BOTH {
+                for port in node_meta.ports(dir) {
+                    self.port_meta[port] = PortEntry::Port(PortMeta::new(new_node, dir));
                 }
             }
 
@@ -952,11 +919,14 @@ impl PortGraph {
 
     /// Compacts the storage of ports in the portgraph so that all ports are stored consecutively.
     ///
+    /// Shrinks the port capacity of every node to match the number of ports it contains.
+    ///
     /// Every time a port is moved, the `rekey` function will be called with is old and new index.
     pub fn compact_ports<F>(&mut self, mut rekey: F)
     where
         F: FnMut(PortIndex, PortIndex),
     {
+        // Compact the links vector, ignoring free ports.
         let mut new_index = 0;
         for old_index in 0..self.port_link.len() {
             if let PortEntry::Free = self.port_meta[old_index] {
@@ -979,6 +949,7 @@ impl PortGraph {
         }
         self.port_link.truncate(new_index);
 
+        // Compact the metadata vector
         let mut new_index = 0;
         let mut old_index = 0;
         self.port_meta.retain(|port_meta| {
@@ -992,16 +963,17 @@ impl PortGraph {
 
             // If we are moving the first port in a node's port list, we have to update the node.
             let node_entry = &mut self.node_meta[port_meta.node().index()];
-
             let NodeEntry::Node(node_meta) = *node_entry else {
                 unreachable!("port must be attached to a valid node")
             };
-
-            if node_meta.port_list() == Some(old_port) {
+            if node_meta.port_list() == old_port {
+                // Update the node's port list, and reduce the capacity to match
+                // the number of ports.
                 *node_entry = NodeEntry::Node(NodeMeta::new(
-                    Some(new_port),
+                    new_port,
                     node_meta.incoming(),
                     node_meta.outgoing(),
+                    node_meta.port_count() as u16,
                 ));
             }
 
@@ -1071,21 +1043,12 @@ impl PortGraph {
     ) where
         F: FnMut(PortIndex, Option<PortIndex>),
     {
-        assert!(incoming < NodeMeta::MAX_INCOMING);
-        assert!(outgoing < NodeMeta::MAX_OUTGOING);
-
         let node_meta = self.node_meta_valid(node).expect("Node must be valid");
-        let Some(port_list) = node_meta.port_list() else {
-            assert_eq!(incoming + outgoing, 0, "The total number of ports must remain 0");
-            return;
-        };
-
-        let old_incoming = node_meta.incoming() as usize;
-        let old_outgoing = node_meta.outgoing() as usize;
-        assert_eq!(
-            incoming + outgoing,
-            old_incoming + old_outgoing,
-            "The total number of ports must not change"
+        let new_meta = NodeMeta::new(
+            node_meta.port_list(),
+            incoming as u16,
+            outgoing as u16,
+            node_meta.capacity() as u16,
         );
 
         // Disconnect any port to be removed.
@@ -1098,20 +1061,7 @@ impl PortGraph {
             rekey(port, None);
         }
 
-        let ports_start = port_list.index();
-        let ports_end = ports_start + old_incoming + old_outgoing;
-        let old_out_indices = (ports_start + old_incoming)..ports_end;
-        let out_indices = (ports_start + incoming)..ports_end;
-
-        // Choose to move the ports from the start or from the end of the
-        // list, to avoid overwriting valid data.
-        let move_pairs: Box<dyn Iterator<Item = _>> = if old_incoming > incoming {
-            Box::new(old_out_indices.zip(out_indices))
-        } else {
-            Box::new(old_out_indices.zip(out_indices).rev())
-        };
-
-        for (old, new) in move_pairs {
+        let move_port = |(old, new)| {
             let old_port = PortIndex::new(old);
             let new_port = PortIndex::new(new);
             self.port_link[new] = self.port_link[old];
@@ -1120,28 +1070,33 @@ impl PortGraph {
             if let Some(link) = self.port_link[new] {
                 self.port_link[link.index()] = Some(new_port);
             }
-        }
+        };
 
-        // Initialize the new (input or output) ports
-        if old_incoming > incoming {
-            for i in 0..(old_incoming - incoming) {
-                let port = ports_start + incoming + old_outgoing + i;
-                self.port_link[port] = None;
-                self.port_meta[port] = PortEntry::Port(PortMeta::new(node, Direction::Outgoing));
-            }
+        // Choose whether to move the ports starting from the first or from the
+        // last depending on the shift direction, to avoid overwriting valid
+        // data.
+        let pairs = node_meta.outgoing_ports().zip(new_meta.outgoing_ports());
+        if (node_meta.incoming() as usize) > incoming {
+            pairs.for_each(move_port);
         } else {
-            for i in 0..(incoming - old_incoming) {
-                let port = ports_start + old_incoming + i;
+            pairs.rev().for_each(move_port);
+        };
+
+        // Initialize the new ports
+        for dir in Direction::BOTH {
+            let existing = node_meta.num_ports(dir) as usize;
+            for port in new_meta.ports(dir).skip(existing) {
                 self.port_link[port] = None;
-                self.port_meta[port] = PortEntry::Port(PortMeta::new(node, Direction::Incoming));
+                self.port_meta[port] = PortEntry::Port(PortMeta::new(node, dir));
             }
         }
+        // Empty ports that are no longer used.
+        for port in new_meta.port_count()..node_meta.port_count() {
+            self.port_link[port] = None;
+            self.port_meta[port] = PortEntry::Free;
+        }
 
-        self.node_meta[node.index()] = NodeEntry::Node(NodeMeta::new(
-            Some(port_list),
-            incoming as u16,
-            outgoing as u16,
-        ));
+        self.node_meta[node.index()] = NodeEntry::Node(new_meta);
     }
 }
 
@@ -1156,45 +1111,108 @@ impl Default for PortGraph {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 struct NodeMeta {
     /// The index of the first port in the port list.
-    /// If the node has no ports, this will be `None`.
-    port_list: Option<PortIndex>,
+    /// If the node has no ports, this will point to the index 0.
+    port_list: PortIndex,
     /// The number of incoming ports plus 1.
     /// We use the `NonZeroU16` here to ensure that `NodeEntry` is 8 bytes.
     incoming: NonZeroU16,
     /// The number of outgoing ports.
     outgoing: u16,
+    /// The port capacity allocated to this node. Changing the number of ports
+    /// up to this capacity does not require reallocation.
+    capacity: u16,
 }
 
 impl NodeMeta {
     /// The maximum number of incoming ports for a node.
     /// This is restricted by the `NonZeroU16` representation.
-    const MAX_INCOMING: usize = u16::MAX as usize;
+    const MAX_INCOMING: usize = u16::MAX as usize - 1;
     /// The maximum number of outgoing ports for a node.
-    const MAX_OUTGOING: usize = u16::MAX as usize + 1;
+    const MAX_OUTGOING: usize = u16::MAX as usize;
 
     #[inline]
-    pub fn new(port_list: Option<PortIndex>, incoming: u16, outgoing: u16) -> Self {
+    pub fn new(port_list: PortIndex, incoming: u16, outgoing: u16, capacity: u16) -> Self {
+        assert!(incoming <= Self::MAX_INCOMING as u16);
+        assert!(outgoing <= Self::MAX_OUTGOING as u16);
+        assert!(incoming.saturating_add(outgoing) <= capacity);
+        assert!(capacity > 0 || port_list.index() == 0);
         Self {
             port_list,
-            // SAFETY: The value cannot be zero
+            // SAFETY: The value cannot be zero, and won't overflow.
             incoming: unsafe { NonZeroU16::new_unchecked(incoming + 1) },
             outgoing,
+            capacity,
         }
     }
 
     #[inline]
-    pub fn port_list(&self) -> Option<PortIndex> {
+    pub fn port_list(&self) -> PortIndex {
         self.port_list
     }
 
+    /// Returns the number of incoming ports.
     #[inline]
     pub fn incoming(&self) -> u16 {
         u16::from(self.incoming).wrapping_sub(1)
     }
 
+    /// Returns the number of outgoing ports.
     #[inline]
     pub fn outgoing(&self) -> u16 {
         self.outgoing
+    }
+
+    /// Returns the number of ports in a given direction.
+    pub fn num_ports(&self, dir: Direction) -> u16 {
+        match dir {
+            Direction::Incoming => self.incoming(),
+            Direction::Outgoing => self.outgoing(),
+        }
+    }
+
+    /// Returns the total number ports.
+    #[inline]
+    pub fn port_count(&self) -> usize {
+        self.outgoing as usize + self.incoming() as usize
+    }
+
+    /// Returns the allocated port capacity for this node.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.capacity as usize
+    }
+
+    /// Returns a range over the port indices of this node.
+    #[inline]
+    pub fn all_ports(&self) -> Range<usize> {
+        let start = self.port_list.index();
+        let end = start + self.incoming() as usize + self.outgoing() as usize;
+        start..end
+    }
+
+    /// Returns a range over the port indices of this node in a given direction.
+    #[inline]
+    pub fn ports(&self, direction: Direction) -> Range<usize> {
+        match direction {
+            Direction::Incoming => self.incoming_ports(),
+            Direction::Outgoing => self.outgoing_ports(),
+        }
+    }
+
+    /// Returns a range over the incoming port indices of this node.
+    #[inline]
+    pub fn incoming_ports(&self) -> Range<usize> {
+        let start = self.port_list.index();
+        let end = start + self.incoming() as usize;
+        start..end
+    }
+
+    /// Returns a range over the outgoing port indices of this node.
+    #[inline]
+    pub fn outgoing_ports(&self) -> Range<usize> {
+        let start = self.port_list.index() + self.incoming() as usize;
+        let end = start + self.outgoing() as usize;
+        start..end
     }
 }
 


### PR DESCRIPTION
Adds a port `capacity` field to `NodeMeta`. This lets us avoid reallocations when reducing the number of ports in a node.

- When reducing the total number of ports in a node, we can keep the allocated slab leaving empty spaces at the end.
- When increasing the number of ports over the capacity, we overallocate ports by rounding the slab size to the next power of two.
  - On one hand, this reduces the number of allocations when adding ports repeatedly
  - On the other hand, this makes more nodes share their slab sizes, increasing the hit-rate on the port slab free list.
- `add_node` does not overallocate. This avoids wasting space for nodes that never change their port count.

Closes #16 

## Benchmarks 

<details>
  <summary>Benchmark result vs HEAD (rounding up to powers of two)</summary>

```
graph creation/make_line_graph/100
                        time:   [2.3621 µs 2.4244 µs 2.5154 µs]
                        change: [-10.357% -5.4832% -0.9214%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe
graph creation/make_line_graph/10000
                        time:   [223.35 µs 226.47 µs 230.07 µs]
                        change: [-21.620% -16.660% -11.388%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
graph creation/make_line_graph/1000000
                        time:   [29.407 ms 29.956 ms 30.625 ms]
                        change: [+0.2224% +2.8575% +5.5865%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 18 outliers among 100 measurements (18.00%)
  7 (7.00%) high mild
  11 (11.00%) high severe

graph cloning/clone_line_graph/100
                        time:   [204.21 ns 209.14 ns 215.12 ns]
                        change: [+14.237% +24.651% +33.621%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 15 outliers among 100 measurements (15.00%)
  3 (3.00%) high mild
  12 (12.00%) high severe
graph cloning/clone_line_graph/10000
                        time:   [11.677 µs 11.883 µs 12.129 µs]
                        change: [+13.742% +18.542% +23.890%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
graph cloning/clone_line_graph/1000000
                        time:   [8.4159 ms 8.5450 ms 8.6957 ms]
                        change: [+31.165% +34.888% +38.314%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 17 outliers among 100 measurements (17.00%)
  12 (12.00%) high mild
  5 (5.00%) high severe

remove vertices unordered/remove_vertices_unordered/100
                        time:   [5.7799 µs 5.8660 µs 5.9672 µs]
                        change: [-3.9430% +0.2570% +4.2860%] (p = 0.91 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe
remove vertices unordered/remove_vertices_unordered/1000
                        time:   [90.803 µs 92.075 µs 93.532 µs]
                        change: [-14.063% -10.987% -7.6757%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) high mild
  8 (8.00%) high severe
remove vertices unordered/remove_vertices_unordered/10000
                        time:   [1.0335 ms 1.0473 ms 1.0632 ms]
                        change: [-18.151% -11.680% -5.4022%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe

resize the amount of ports/set_num_ports/100
                        time:   [3.7928 µs 3.8546 µs 3.9317 µs]
                        change: [-13.858% -7.7501% -2.1995%] (p = 0.01 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe
resize the amount of ports/set_num_ports/1000
                        time:   [34.425 µs 34.985 µs 35.670 µs]
                        change: [-5.1483% -1.2513% +3.4197%] (p = 0.60 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe
resize the amount of ports/set_num_ports/10000
                        time:   [344.59 µs 351.70 µs 360.68 µs]
                        change: [-4.3787% +1.0549% +6.5356%] (p = 0.72 > 0.05)
                        No change in performance detected.
Found 18 outliers among 100 measurements (18.00%)
  3 (3.00%) high mild
  15 (15.00%) high severe

rewrite a single node/apply_rewrite
                        time:   [607.81 ns 616.98 ns 627.99 ns]
                        change: [-1.7480% +30.912% +94.279%] (p = 0.28 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe
rewrite a single node/apply_weighted_rewrite
                        time:   [791.68 ns 810.33 ns 832.25 ns]
                        change: [-24.714% -8.8822% +4.6530%] (p = 0.41 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe

initialize a tree hierarchy/initialize_tree_hierarchy/100
                        time:   [1.4171 µs 1.4504 µs 1.4989 µs]
                        change: [-5.8650% -2.2323% +1.0019%] (p = 0.23 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe
initialize a tree hierarchy/initialize_tree_hierarchy/1000
                        time:   [13.762 µs 14.086 µs 14.504 µs]
                        change: [-2.3758% +3.1493% +10.825%] (p = 0.39 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe
initialize a tree hierarchy/initialize_tree_hierarchy/10000
                        time:   [137.61 µs 141.06 µs 145.54 µs]
                        change: [-9.8628% -6.3713% -3.0801%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  8 (8.00%) high mild
  8 (8.00%) high severe

traverse a tree hierarchy/traverse_tree_hierarchy/100
                        time:   [980.65 ns 1.0001 µs 1.0260 µs]
                        change: [-12.216% -7.4472% -0.8537%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
traverse a tree hierarchy/traverse_tree_hierarchy/1000
                        time:   [10.604 µs 11.010 µs 11.510 µs]
                        change: [-12.234% -8.3995% -4.1042%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) high mild
  13 (13.00%) high severe
traverse a tree hierarchy/traverse_tree_hierarchy/100000
                        time:   [1.1137 ms 1.1339 ms 1.1570 ms]
                        change: [-9.1071% -5.6256% -1.7707%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
  ```
</details>


<details>
  <summary>Benchmark result vs HEAD (without over-allocation)</summary>

```
graph creation/make_line_graph/100
                        time:   [2.3628 µs 2.4109 µs 2.4741 µs]
                        change: [-9.8052% -4.7030% +0.0681%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 17 outliers among 100 measurements (17.00%)
  7 (7.00%) high mild
  10 (10.00%) high severe
graph creation/make_line_graph/10000
                        time:   [227.10 µs 236.46 µs 248.46 µs]
                        change: [-19.299% -13.540% -7.6697%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  4 (4.00%) high mild
  13 (13.00%) high severe
graph creation/make_line_graph/1000000
                        time:   [30.567 ms 31.161 ms 31.851 ms]
                        change: [+4.2117% +6.9957% +9.6786%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  10 (10.00%) high mild
  4 (4.00%) high severe

graph cloning/clone_line_graph/100
                        time:   [199.70 ns 204.35 ns 210.43 ns]
                        change: [+13.923% +24.342% +33.825%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 16 outliers among 100 measurements (16.00%)
  2 (2.00%) high mild
  14 (14.00%) high severe
graph cloning/clone_line_graph/10000
                        time:   [10.921 µs 11.071 µs 11.271 µs]
                        change: [+6.4685% +10.190% +13.700%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
graph cloning/clone_line_graph/1000000
                        time:   [7.9041 ms 8.0342 ms 8.1811 ms]
                        change: [+23.282% +26.825% +30.401%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

remove vertices unordered/remove_vertices_unordered/100
                        time:   [5.6774 µs 5.7801 µs 5.8974 µs]
                        change: [-5.9551% -2.4399% +0.9624%] (p = 0.19 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
remove vertices unordered/remove_vertices_unordered/1000
                        time:   [89.617 µs 90.811 µs 92.307 µs]
                        change: [-13.691% -10.151% -6.3747%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
remove vertices unordered/remove_vertices_unordered/10000
                        time:   [1.0308 ms 1.0518 ms 1.0793 ms]
                        change: [-17.265% -10.882% -5.0397%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  5 (5.00%) high mild
  10 (10.00%) high severe

resize the amount of ports/set_num_ports/100
                        time:   [3.7289 µs 3.8103 µs 3.9141 µs]
                        change: [-13.412% -6.6929% -0.3216%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  3 (3.00%) high mild
  12 (12.00%) high severe
resize the amount of ports/set_num_ports/1000
                        time:   [33.652 µs 33.930 µs 34.260 µs]
                        change: [-9.0490% -6.4436% -3.9867%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  8 (8.00%) high mild
  7 (7.00%) high severe
resize the amount of ports/set_num_ports/10000
                        time:   [337.96 µs 342.34 µs 347.37 µs]
                        change: [-5.8758% -0.1887% +5.5332%] (p = 0.95 > 0.05)
                        No change in performance detected.
Found 18 outliers among 100 measurements (18.00%)
  6 (6.00%) high mild
  12 (12.00%) high severe

rewrite a single node/apply_rewrite
                        time:   [604.26 ns 619.53 ns 637.02 ns]
                        change: [-5.9773% +16.311% +67.409%] (p = 0.52 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  8 (8.00%) high mild
  7 (7.00%) high severe
rewrite a single node/apply_weighted_rewrite
                        time:   [784.50 ns 813.07 ns 850.07 ns]
                        change: [-18.187% +14.953% +75.016%] (p = 0.65 > 0.05)
                        No change in performance detected.
Found 21 outliers among 100 measurements (21.00%)
  2 (2.00%) low mild
  6 (6.00%) high mild
  13 (13.00%) high severe

initialize a tree hierarchy/initialize_tree_hierarchy/100
                        time:   [1.4563 µs 1.4918 µs 1.5360 µs]
                        change: [-2.5515% +1.4876% +5.3660%] (p = 0.47 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
initialize a tree hierarchy/initialize_tree_hierarchy/1000
                        time:   [13.722 µs 13.939 µs 14.223 µs]
                        change: [-2.1899% +1.6609% +6.0386%] (p = 0.45 > 0.05)
                        No change in performance detected.
Found 17 outliers among 100 measurements (17.00%)
  4 (4.00%) high mild
  13 (13.00%) high severe
initialize a tree hierarchy/initialize_tree_hierarchy/10000
                        time:   [143.70 µs 148.14 µs 153.30 µs]
                        change: [-4.1785% +1.1261% +6.6717%] (p = 0.70 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe

traverse a tree hierarchy/traverse_tree_hierarchy/100
                        time:   [997.34 ns 1.0204 µs 1.0525 µs]
                        change: [-7.6655% -3.7554% +0.5588%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe
traverse a tree hierarchy/traverse_tree_hierarchy/1000
                        time:   [11.021 µs 11.325 µs 11.704 µs]
                        change: [-2.8135% +2.2200% +6.8067%] (p = 0.39 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
traverse a tree hierarchy/traverse_tree_hierarchy/100000
                        time:   [888.06 µs 909.09 µs 937.04 µs]
                        change: [-20.588% -16.597% -12.081%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```
</details>

Performance in general is better, except for copy operations due to the increased memory use. The decision on whether to overallocate (and which grow factor to use) is not so clear. It may be interesting to come back to it once we have real-world use cases.

## Not in this PR

There are multiple ways in which we could make the allocator smarter/more efficient.
We could look for free slabs with similar size to the requested capacity when there is no exact match.
We could also use exponentially sized buckets, now that we have the option to overallocate.
...