### PR TITLE
Add `NodePorts::as_range`

### DIFF
--- a/src/portgraph.rs
+++ b/src/portgraph.rs
@@ -698,13 +698,13 @@ impl PortGraph {
         Neighbours::from_node_links(self, self.links(node, direction))
     }
 
-    /// Iterates over the input neighbours of the `node`. Shorthand for [`PortGraph::links`].
+    /// Iterates over the input neighbours of the `node`. Shorthand for [`PortGraph::neighbours`].
     #[inline]
     pub fn input_neighbours(&self, node: NodeIndex) -> Neighbours<'_> {
         self.neighbours(node, Direction::Incoming)
     }
 
-    /// Iterates over the output neighbours of the `node`. Shorthand for [`PortGraph::links`].
+    /// Iterates over the output neighbours of the `node`. Shorthand for [`PortGraph::neighbours`].
     #[inline]
     pub fn output_neighbours(&self, node: NodeIndex) -> Neighbours<'_> {
         self.neighbours(node, Direction::Outgoing)

--- a/src/portgraph/iter.rs
+++ b/src/portgraph/iter.rs
@@ -15,6 +15,14 @@ pub struct NodePorts {
     pub(super) indices: Range<usize>,
 }
 
+impl NodePorts {
+    /// Return the leftover ports in the iterator as a range of integer indexes.
+    #[inline]
+    pub fn as_range(&self) -> Range<usize> {
+        self.indices.clone()
+    }
+}
+
 impl Iterator for NodePorts {
     type Item = PortIndex;
 


### PR DESCRIPTION
Adds a method to query the range from the node ports iterator.
Also fixes a couple minor doc errors.