### PR TITLE
Generic trait for SecondaryMaps

### DIFF
--- a/src/algorithms/dominators.rs
+++ b/src/algorithms/dominators.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 /// by its parent.
 ///
 /// The `Map` type parameter specifies the type of the secondary map that is used
-/// to store the dominator tree data. The default is [`UnmanagedMap`].
+/// to store the dominator tree data. The default is [`UnmanagedDenseMap`].
 ///
 /// # Example
 ///
@@ -57,7 +57,7 @@ where
 /// when computing the dominator tree.
 ///
 /// The `Map` type parameter specifies the type of the secondary map that is
-/// used to store the dominator tree data. The default is [`UnmanagedMap`]. For
+/// used to store the dominator tree data. The default is [`UnmanagedDenseMap`]. For
 /// dominator trees over sparse node indices, `HashMap` or `BTreeMap` may be
 /// more efficient.
 ///

--- a/src/algorithms/dominators.rs
+++ b/src/algorithms/dominators.rs
@@ -1,5 +1,5 @@
 use super::postorder_filtered;
-use crate::unmanaged::UnmanagedMap;
+use crate::unmanaged::UnmanagedDenseMap;
 use crate::{Direction, NodeIndex, PortGraph, PortIndex, SecondaryMap};
 use std::cmp::Ordering;
 
@@ -115,7 +115,7 @@ where
 /// A dominator tree for a [`PortGraph`].
 ///
 /// See [`dominators`] for more information.
-pub struct DominatorTree<Map = UnmanagedMap<NodeIndex, Option<NodeIndex>>> {
+pub struct DominatorTree<Map = UnmanagedDenseMap<NodeIndex, Option<NodeIndex>>> {
     root: NodeIndex,
     /// The immediate dominator of each node.
     idom: Map,
@@ -134,7 +134,7 @@ where
     ) -> Self {
         // We traverse the graph in post order starting at the `entry` node.
         // We associate each node that we encounter with its index within the traversal.
-        let mut node_to_index = UnmanagedMap::with_capacity(graph.node_capacity());
+        let mut node_to_index = UnmanagedDenseMap::with_capacity(graph.node_capacity());
         let mut index_to_node = Vec::with_capacity(graph.node_capacity());
 
         for (index, node) in postorder_filtered(

--- a/src/algorithms/dominators.rs
+++ b/src/algorithms/dominators.rs
@@ -1,10 +1,13 @@
 use super::postorder_filtered;
-use crate::secondary::SecondaryMap;
-use crate::{Direction, NodeIndex, PortGraph, PortIndex};
+use crate::unmanaged::UnmanagedMap;
+use crate::{Direction, NodeIndex, PortGraph, PortIndex, SecondaryMap};
 use std::cmp::Ordering;
 
 /// Returns a dominator tree for a [`PortGraph`], where each node is dominated
 /// by its parent.
+///
+/// The `Map` type parameter specifies the type of the secondary map that is used
+/// to store the dominator tree data. The default is [`UnmanagedMap`].
 ///
 /// # Example
 ///
@@ -14,7 +17,7 @@ use std::cmp::Ordering;
 ///    ┗> d ┛
 ///
 /// ```
-/// # use portgraph::{algorithms::dominators, Direction, PortGraph};
+/// # use portgraph::{algorithms::{dominators, DominatorTree}, Direction, PortGraph};
 /// let mut graph = PortGraph::with_capacity(5, 10);
 /// let a = graph.add_node(0,2);
 /// let b = graph.add_node(1,1);
@@ -28,7 +31,7 @@ use std::cmp::Ordering;
 /// graph.link_nodes(d, 0, c, 1).unwrap();
 /// graph.link_nodes(c, 0, e, 0).unwrap();
 ///
-/// let tree = dominators(&graph, a, Direction::Outgoing);
+/// let tree: DominatorTree = dominators(&graph, a, Direction::Outgoing);
 /// assert_eq!(tree.root(), a);
 /// assert_eq!(tree.immediate_dominator(a), None);
 /// assert_eq!(tree.immediate_dominator(b), Some(a));
@@ -36,7 +39,14 @@ use std::cmp::Ordering;
 /// assert_eq!(tree.immediate_dominator(d), Some(a));
 /// assert_eq!(tree.immediate_dominator(e), Some(c));
 /// ```
-pub fn dominators(graph: &PortGraph, entry: NodeIndex, direction: Direction) -> DominatorTree {
+pub fn dominators<Map>(
+    graph: &PortGraph,
+    entry: NodeIndex,
+    direction: Direction,
+) -> DominatorTree<Map>
+where
+    Map: SecondaryMap<NodeIndex, Option<NodeIndex>>,
+{
     DominatorTree::new(graph, entry, direction, |_| true, |_, _| true)
 }
 
@@ -46,15 +56,18 @@ pub fn dominators(graph: &PortGraph, entry: NodeIndex, direction: Direction) -> 
 /// If the filter predicate returns `false` for a node or port, it is ignored
 /// when computing the dominator tree.
 ///
+/// The `Map` type parameter specifies the type of the secondary map that is
+/// used to store the dominator tree data. The default is [`UnmanagedMap`]. For
+/// dominator trees over sparse node indices, `HashMap` or `BTreeMap` may be
+/// more efficient.
+///
 /// # Example
 ///
 /// This example runs the dominator algorithm on the following branching graph:
-/// a ─┬> b ┐
-///    │    ├─> c ─> e
-/// f ─┴> d ┴────────^
+/// a ─┬> b ┐ │    ├─> c ─> e f ─┴> d ┴────────^
 ///
 /// ```
-/// # use portgraph::{algorithms::dominators_filtered, Direction, PortGraph};
+/// # use portgraph::{algorithms::{dominators_filtered, DominatorTree}, Direction, PortGraph};
 /// let mut graph = PortGraph::with_capacity(5, 10);
 /// let a = graph.add_node(0,2);
 /// let b = graph.add_node(1,1);
@@ -71,7 +84,7 @@ pub fn dominators(graph: &PortGraph, entry: NodeIndex, direction: Direction) -> 
 /// graph.link_nodes(d, 1, e, 1).unwrap();
 /// graph.link_nodes(f, 0, d, 1).unwrap();
 ///
-/// let tree = dominators_filtered(
+/// let tree: DominatorTree = dominators_filtered(
 ///     &graph,
 ///     a,
 ///     Direction::Outgoing,
@@ -86,26 +99,32 @@ pub fn dominators(graph: &PortGraph, entry: NodeIndex, direction: Direction) -> 
 /// assert_eq!(tree.immediate_dominator(e), Some(c));
 /// assert_eq!(tree.immediate_dominator(f), None);
 /// ```
-pub fn dominators_filtered(
+pub fn dominators_filtered<Map>(
     graph: &PortGraph,
     entry: NodeIndex,
     direction: Direction,
     node_filter: impl FnMut(NodeIndex) -> bool,
     port_filter: impl FnMut(NodeIndex, PortIndex) -> bool,
-) -> DominatorTree {
+) -> DominatorTree<Map>
+where
+    Map: SecondaryMap<NodeIndex, Option<NodeIndex>>,
+{
     DominatorTree::new(graph, entry, direction, node_filter, port_filter)
 }
 
 /// A dominator tree for a [`PortGraph`].
 ///
 /// See [`dominators`] for more information.
-pub struct DominatorTree {
+pub struct DominatorTree<Map = UnmanagedMap<NodeIndex, Option<NodeIndex>>> {
     root: NodeIndex,
     /// The immediate dominator of each node.
-    idom: SecondaryMap<NodeIndex, Option<NodeIndex>>,
+    idom: Map,
 }
 
-impl DominatorTree {
+impl<Map> DominatorTree<Map>
+where
+    Map: SecondaryMap<NodeIndex, Option<NodeIndex>>,
+{
     fn new(
         graph: &PortGraph,
         entry: NodeIndex,
@@ -115,7 +134,7 @@ impl DominatorTree {
     ) -> Self {
         // We traverse the graph in post order starting at the `entry` node.
         // We associate each node that we encounter with its index within the traversal.
-        let mut node_to_index = SecondaryMap::with_capacity(graph.node_capacity());
+        let mut node_to_index = UnmanagedMap::with_capacity(graph.node_capacity());
         let mut index_to_node = Vec::with_capacity(graph.node_capacity());
 
         for (index, node) in postorder_filtered(
@@ -178,11 +197,11 @@ impl DominatorTree {
         }
 
         // Translate into a secondary map with `NodeIndex`s.
-        let mut idom = SecondaryMap::with_capacity(graph.node_capacity());
+        let mut idom = Map::with_capacity(graph.node_capacity());
 
         for (index, dominator) in dominators.into_iter().take(num_nodes - 1).enumerate() {
             debug_assert_ne!(dominator, usize::MAX);
-            idom[index_to_node[index]] = Some(index_to_node[dominator]);
+            idom.set(index_to_node[index], Some(index_to_node[dominator]));
         }
 
         Self { root: entry, idom }
@@ -197,7 +216,7 @@ impl DominatorTree {
     #[inline]
     /// Returns the immediate dominator of a node.
     pub fn immediate_dominator(&self, node: NodeIndex) -> Option<NodeIndex> {
-        self.idom[node]
+        *self.idom.get(node)
     }
 }
 
@@ -235,7 +254,7 @@ mod tests {
         graph.link_nodes(c, 0, e, 0).unwrap();
 
         // From `a`
-        let tree = dominators(&graph, a, Direction::Outgoing);
+        let tree: DominatorTree = dominators(&graph, a, Direction::Outgoing);
         assert_eq!(tree.root(), a);
         assert_eq!(tree.immediate_dominator(a), None);
         assert_eq!(tree.immediate_dominator(b), Some(a));
@@ -244,7 +263,7 @@ mod tests {
         assert_eq!(tree.immediate_dominator(e), Some(c));
 
         // Backwards from `c`
-        let tree = dominators(&graph, c, Direction::Incoming);
+        let tree: DominatorTree = dominators(&graph, c, Direction::Incoming);
         assert_eq!(tree.root(), c);
         assert_eq!(tree.immediate_dominator(a), Some(c));
         assert_eq!(tree.immediate_dominator(b), Some(c));
@@ -275,7 +294,7 @@ mod tests {
         graph.link_nodes(f, 0, d, 1).unwrap();
 
         // From `a`
-        let tree = dominators_filtered(
+        let tree: DominatorTree = dominators_filtered(
             &graph,
             a,
             Direction::Outgoing,
@@ -291,7 +310,7 @@ mod tests {
         assert_eq!(tree.immediate_dominator(f), None);
 
         // Backwards from `c`
-        let tree = dominators(&graph, c, Direction::Incoming);
+        let tree: DominatorTree = dominators(&graph, c, Direction::Incoming);
         assert_eq!(tree.root(), c);
         assert_eq!(tree.immediate_dominator(a), Some(c));
         assert_eq!(tree.immediate_dominator(b), Some(c));
@@ -323,7 +342,7 @@ mod tests {
         graph.link_nodes(d, 1, e, 1).unwrap();
         graph.link_nodes(e, 0, d, 2).unwrap();
 
-        let dominators = dominators(&graph, entry, Direction::Outgoing);
+        let dominators: DominatorTree = dominators(&graph, entry, Direction::Outgoing);
 
         assert_eq!(dominators.root(), entry);
         assert_eq!(dominators.immediate_dominator(entry), None);

--- a/src/algorithms/toposort.rs
+++ b/src/algorithms/toposort.rs
@@ -1,11 +1,14 @@
-use crate::{Direction, NodeIndex, PortGraph, PortIndex};
+use crate::{Direction, NodeIndex, PortGraph, PortIndex, SecondaryMap};
 use bitvec::prelude::BitVec;
 use std::{collections::VecDeque, iter::FusedIterator};
 
 /// Returns an iterator over a [`PortGraph`] in topological order.
 ///
-/// Optimized for full graph traversal, i.e. when all nodes are reachable from the source nodes.
-/// It uses O(n) memory, where n is the number of ports in the graph.
+/// The `Map` type parameter specifies the type of the secondary map that is
+/// used to store the dominator tree data. The default is [`BitVec`], which is
+/// efficient for full graph traversal, i.e. when all nodes are reachable from
+/// the source nodes. For sparse traversals, `HashMap` or `BTreeMap` may be more
+/// efficient.
 ///
 /// Implements [Kahn's algorithm](https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm).
 ///
@@ -22,11 +25,14 @@ use std::{collections::VecDeque, iter::FusedIterator};
 /// let topo = toposort(&graph, [node_a], Direction::Outgoing);
 /// assert_eq!(topo.collect::<Vec<_>>(), [node_a, node_b]);
 /// ```
-pub fn toposort(
+pub fn toposort<Map>(
     graph: &PortGraph,
     source: impl IntoIterator<Item = NodeIndex>,
     direction: Direction,
-) -> TopoSort {
+) -> TopoSort<'_, Map>
+where
+    Map: SecondaryMap<PortIndex, bool>,
+{
     TopoSort::new(graph, source, direction, None, None)
 }
 
@@ -36,9 +42,11 @@ pub fn toposort(
 ///
 /// If the filter closures return false for a node or port, it is skipped.
 ///
-/// Optimized for full graph traversal, i.e. when all nodes are reachable from
-/// the source nodes. It uses O(n) memory, where n is the number of ports in the
-/// graph.
+/// The `Map` type parameter specifies the type of the secondary map that is
+/// used to store the dominator tree data. The default is [`BitVec`], which is
+/// efficient for full graph traversal, i.e. when all nodes are reachable from
+/// the source nodes. For sparse traversals, `HashMap` or `BTreeMap` may be more
+/// efficient.
 ///
 /// Implements [Kahn's
 /// algorithm](https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm).
@@ -66,13 +74,16 @@ pub fn toposort(
 /// );
 /// assert_eq!(topo.collect::<Vec<_>>(), [node_a, node_b]);
 /// ```
-pub fn toposort_filtered<'graph>(
+pub fn toposort_filtered<'graph, Map>(
     graph: &'graph PortGraph,
     source: impl IntoIterator<Item = NodeIndex>,
     direction: Direction,
     node_filter: impl FnMut(NodeIndex) -> bool + 'graph,
     port_filter: impl FnMut(NodeIndex, PortIndex) -> bool + 'graph,
-) -> TopoSort {
+) -> TopoSort<'_, Map>
+where
+    Map: SecondaryMap<PortIndex, bool>,
+{
     TopoSort::new(
         graph,
         source,
@@ -87,9 +98,9 @@ pub fn toposort_filtered<'graph>(
 /// See [`toposort`] for more information.
 ///
 /// Implements [Kahn's algorithm](https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm).
-pub struct TopoSort<'graph> {
+pub struct TopoSort<'graph, Map = BitVec> {
     graph: &'graph PortGraph,
-    remaining_ports: BitVec,
+    visited_ports: Map,
     /// A VecDeque is used for the node list to produce a canonical ordering,
     /// as successors of nodes already have a canonical ordering due to ports.
     candidate_nodes: VecDeque<NodeIndex>,
@@ -105,7 +116,10 @@ pub struct TopoSort<'graph> {
     port_filter: Option<Box<dyn FnMut(NodeIndex, PortIndex) -> bool + 'graph>>,
 }
 
-impl<'graph> TopoSort<'graph> {
+impl<'graph, Map> TopoSort<'graph, Map>
+where
+    Map: SecondaryMap<PortIndex, bool>,
+{
     /// Initialises a new topological sort of a portgraph in a specified direction
     /// starting at a collection of `source` nodes.
     fn new(
@@ -115,8 +129,7 @@ impl<'graph> TopoSort<'graph> {
         mut node_filter: Option<Box<dyn FnMut(NodeIndex) -> bool + 'graph>>,
         port_filter: Option<Box<dyn FnMut(NodeIndex, PortIndex) -> bool + 'graph>>,
     ) -> Self {
-        let mut remaining_ports = BitVec::with_capacity(graph.port_capacity());
-        remaining_ports.resize(graph.port_capacity(), true);
+        let mut visited_ports: Map = SecondaryMap::new();
 
         let candidate_nodes: VecDeque<_> = if let Some(node_filter) = node_filter.as_mut() {
             source.into_iter().filter(|&n| node_filter(n)).collect()
@@ -127,13 +140,13 @@ impl<'graph> TopoSort<'graph> {
         // Mark all the candidate ports as visited, so we don't visit them again.
         for node in candidate_nodes.iter() {
             for port in graph.ports(*node, direction.reverse()) {
-                remaining_ports.set(port.index(), false);
+                visited_ports.set(port, true);
             }
         }
 
         Self {
             graph,
-            remaining_ports,
+            visited_ports,
             candidate_nodes,
             direction,
             nodes_seen: 0,
@@ -144,8 +157,10 @@ impl<'graph> TopoSort<'graph> {
 
     /// Returns whether there are ports that have not been visited yet.
     /// If the iterator has seen all nodes this implies that there is a cycle.
-    pub fn ports_remaining(&self) -> impl ExactSizeIterator<Item = PortIndex> + '_ {
-        self.remaining_ports.iter_ones().map(PortIndex::new)
+    pub fn ports_remaining(&self) -> impl DoubleEndedIterator<Item = PortIndex> + '_ {
+        self.graph
+            .ports_iter()
+            .filter(move |&p| !self.visited_ports.get(p))
     }
 
     /// Checks if a node becomes ready once it is visited from `from_port`, i.e.
@@ -159,12 +174,12 @@ impl<'graph> TopoSort<'graph> {
                 // This port must have not been visited yet. Otherwise, the node
                 // would have been already been reported as ready and added to
                 // the candidate list.
-                self.remaining_ports[p.index()]
-            } else if !self.remaining_ports[p.index()] {
+                !self.visited_ports.get(p)
+            } else if *self.visited_ports.get(p) {
                 true
             } else if self.graph.port_link(p).is_none() || self.ignore_port(node, p) {
                 // If the port is not linked or should be ignored, mark it as visited.
-                self.remaining_ports.set(p.index(), false);
+                self.visited_ports.set(p, true);
                 true
             } else {
                 false
@@ -198,7 +213,7 @@ impl<'graph> Iterator for TopoSort<'graph> {
         let node = self.candidate_nodes.pop_front()?;
 
         for port in self.graph.ports(node, self.direction) {
-            self.remaining_ports.set(port.index(), false);
+            self.visited_ports.set(port.index(), true);
 
             if self.ignore_port(node, port) {
                 continue;
@@ -210,7 +225,7 @@ impl<'graph> Iterator for TopoSort<'graph> {
                 if self.becomes_ready(target, link) {
                     self.candidate_nodes.push_back(target);
                 }
-                self.remaining_ports.set(link.index(), false);
+                self.visited_ports.set(link.index(), true);
             }
         }
 

--- a/src/algorithms/toposort.rs
+++ b/src/algorithms/toposort.rs
@@ -122,6 +122,8 @@ where
 {
     /// Initialises a new topological sort of a portgraph in a specified direction
     /// starting at a collection of `source` nodes.
+    ///
+    /// If the default value of `Map` is not `false`, this requires O(#ports) time.
     fn new(
         graph: &'graph PortGraph,
         source: impl IntoIterator<Item = NodeIndex>,
@@ -136,6 +138,13 @@ where
         } else {
             source.into_iter().collect()
         };
+
+        // If the default value of `Map` is not `false`, we must mark all ports as not visited.
+        if visited_ports.default_value() {
+            for port in graph.ports_iter() {
+                visited_ports.set(port, false);
+            }
+        }
 
         // Mark all the candidate ports as visited, so we don't visit them again.
         for node in candidate_nodes.iter() {

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -53,7 +53,7 @@ use std::iter::FusedIterator;
 use std::mem::{replace, take};
 use thiserror::Error;
 
-use crate::unmanaged::UnmanagedMap;
+use crate::unmanaged::UnmanagedDenseMap;
 use crate::NodeIndex;
 
 #[cfg(feature = "serde")]
@@ -68,21 +68,21 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Hierarchy {
-    data: UnmanagedMap<NodeIndex, NodeData>,
+    data: UnmanagedDenseMap<NodeIndex, NodeData>,
 }
 
 impl Hierarchy {
     /// Creates a new empty layout.
     pub fn new() -> Self {
         Self {
-            data: UnmanagedMap::new(),
+            data: UnmanagedDenseMap::new(),
         }
     }
 
     /// Creates a new empty layout with the given capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            data: UnmanagedMap::with_capacity(capacity),
+            data: UnmanagedDenseMap::with_capacity(capacity),
         }
     }
 }

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -53,7 +53,7 @@ use std::iter::FusedIterator;
 use std::mem::{replace, take};
 use thiserror::Error;
 
-use crate::secondary::SecondaryMap;
+use crate::unmanaged::UnmanagedMap;
 use crate::NodeIndex;
 
 #[cfg(feature = "serde")]
@@ -68,21 +68,21 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Hierarchy {
-    data: SecondaryMap<NodeIndex, NodeData>,
+    data: UnmanagedMap<NodeIndex, NodeData>,
 }
 
 impl Hierarchy {
     /// Creates a new empty layout.
     pub fn new() -> Self {
         Self {
-            data: SecondaryMap::new(),
+            data: UnmanagedMap::new(),
         }
     }
 
     /// Creates a new empty layout with the given capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            data: SecondaryMap::with_capacity(capacity),
+            data: UnmanagedMap::with_capacity(capacity),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ pub mod hierarchy;
 pub mod portgraph;
 pub mod secondary;
 pub mod substitute;
+pub mod unmanaged;
 pub mod weights;
 
 #[cfg(feature = "pyo3")]
@@ -82,6 +83,8 @@ pub use crate::hierarchy::Hierarchy;
 pub use crate::portgraph::{LinkError, PortGraph};
 #[doc(inline)]
 pub use crate::secondary::SecondaryMap;
+#[doc(inline)]
+pub use crate::unmanaged::UnmanagedMap;
 #[doc(inline)]
 pub use crate::weights::Weights;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ pub use crate::portgraph::{LinkError, PortGraph};
 #[doc(inline)]
 pub use crate::secondary::SecondaryMap;
 #[doc(inline)]
-pub use crate::unmanaged::UnmanagedMap;
+pub use crate::unmanaged::UnmanagedDenseMap;
 #[doc(inline)]
 pub use crate::weights::Weights;
 

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -31,10 +31,6 @@ pub trait SecondaryMap<K, V> {
     /// Increases the capacity of the secondary map to `capacity`.
     fn ensure_capacity(&mut self, capacity: usize);
 
-    /// Reduces the capacity of the secondary map to `capacity`.
-    /// Stored values higher than `capacity` may be dropped.
-    fn shrink_to(&mut self, capacity: usize);
-
     /// Resizes the secondary map to `new_len`.
     fn resize(&mut self, new_len: usize);
 
@@ -95,11 +91,6 @@ where
     #[inline]
     fn ensure_capacity(&mut self, capacity: usize) {
         BitVec::reserve(self, capacity.saturating_sub(self.capacity()));
-    }
-
-    #[inline]
-    fn shrink_to(&mut self, capacity: usize) {
-        BitVec::resize(self, capacity, false)
     }
 
     #[inline]

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -1,151 +1,66 @@
-//! A dense key-value map used to store graph weights.
-//!
-//! This map does not allocate any memory until a value is modified, returning
-//! references to the default value instead.
-//!
-//! This structure is intended to be used alongside [`PortGraph`], as it does
-//! not keep track of the valid keys.
-//!
-//! For simple cases where the nodes and ports have a single weight each, see
-//! [`Weights`].
-//!
-//! [`PortGraph`]: crate::portgraph::PortGraph
-//! [`Weights`]: crate::weights::Weights
-//!
-//! # Example
-//!
-//! ```
-//! # use portgraph::{PortGraph, NodeIndex, PortIndex};
-//! # use portgraph::secondary::SecondaryMap;
-//!
-//! let mut graph = PortGraph::new();
-//! let mut node_weights = SecondaryMap::<NodeIndex, usize>::new();
-//! let mut port_weights = SecondaryMap::<PortIndex, isize>::new();
-//!
-//! // The weights must be set manually.
-//! let node = graph.add_node(2, 2);
-//! let [in0, in1, ..] = graph.inputs(node).collect::<Vec<_>>()[..] else { unreachable!() };
-//! let [out0, out1, ..] = graph.outputs(node).collect::<Vec<_>>()[..] else { unreachable!() };
-//! node_weights[node] = 42;
-//! port_weights[in1] = 2;
-//! port_weights[out0] = -1;
-//! port_weights[out1] = -2;
-//!
-//! /// Unset weights return the default value.
-//! assert_eq!(port_weights[in0], 0);
-//!
-//! // Graph operations that modify the keys use callbacks to update the weights.
-//! graph.set_num_ports(node, 1, 3, |old, new| {if let Some(new) = new {port_weights.swap(old, new);}});
-//!
-//! // The map does not track item removals, but the user can shrink the map manually.
-//! graph.remove_node(node);
-//! node_weights.shrink_to(graph.node_count());
-//! port_weights.shrink_to(graph.port_count());
-//!
-//! ```
+//! TODO
 
-use std::{
-    marker::PhantomData,
-    mem::{self, MaybeUninit},
-    ops::{Index, IndexMut},
+use std::iter::FusedIterator;
+
+use bitvec::{
+    slice::{BitSlice, IterOnes},
+    vec::BitVec,
 };
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
-/// A dense map from keys to values with default fallbacks.
+/// A map from keys to values that does not manage it's indices.
 ///
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-pub struct SecondaryMap<K, V> {
-    data: Vec<V>,
-    phantom: PhantomData<K>,
-    default: V,
-}
+/// Querying a key that has not been set returns a default value.
+pub trait SecondaryMap<K, V> {
+    /// An iterator over the non-default entries of the secondary map.
+    type Iter<'a>: Iterator<Item = (K, &'a V)> + 'a
+    where
+        Self: 'a,
+        K: 'a,
+        V: 'a;
 
-impl<K: PartialEq, V: PartialEq> PartialEq for SecondaryMap<K, V> {
-    fn eq(&self, other: &Self) -> bool {
-        if self.default != other.default {
-            return false;
-        }
-        let common_len = std::cmp::min(self.data.len(), other.data.len());
-        self.data[..common_len] == other.data[..common_len]
-            && self.data[common_len..].iter().all(|v| v == &self.default)
-            && other.data[common_len..].iter().all(|v| v == &other.default)
-    }
-}
-
-impl<K, V> SecondaryMap<K, V>
-where
-    K: Into<usize> + Copy,
-    V: Clone,
-{
     /// Creates a new secondary map.
     ///
     /// This does not allocate any memory until a value is modified.
-    #[inline]
-    pub fn new() -> Self
-    where
-        V: Default,
-    {
-        Self::with_default(Default::default())
-    }
-
-    /// Creates a new secondary map, specifying the default element.
-    ///
-    /// This does not allocate any memory until a value is modified.
-    #[inline]
-    pub fn with_default(default: V) -> Self {
-        Self {
-            data: Vec::new(),
-            phantom: PhantomData,
-            default,
-        }
-    }
+    fn new() -> Self;
 
     /// Creates a new secondary map with specified capacity.
-    #[inline]
-    pub fn with_capacity(capacity: usize) -> Self
-    where
-        V: Default,
-    {
-        Self::with_capacity_and_default(capacity, Default::default())
-    }
+    fn with_capacity(capacity: usize) -> Self;
 
-    /// Creates a new secondary map with specified capacity and default element.
-    #[inline]
-    pub fn with_capacity_and_default(capacity: usize, default: V) -> Self {
-        Self {
-            data: Vec::with_capacity(capacity),
-            phantom: PhantomData,
-            default,
-        }
-    }
+    /// Returns the default value for the secondary map.
+    /// Any key that has not been set will return this value.
+    fn default_value(&self) -> V;
 
     /// Increases the capacity of the secondary map to `capacity`.
-    ///
-    /// Does nothing when the capacity of the secondary map is already sufficient.
-    pub fn ensure_capacity(&mut self, capacity: usize) {
-        if capacity > self.data.capacity() {
-            self.data.reserve(capacity - self.data.capacity());
-            self.data.resize(capacity, self.default.clone());
-        }
-    }
+    fn ensure_capacity(&mut self, capacity: usize);
 
     /// Reduces the capacity of the secondary map to `capacity`.
-    /// Stored values higher than `capacity` are dropped.
-    ///
-    /// Does nothing when the capacity of the secondary map is already lower.
-    pub fn shrink_to(&mut self, capacity: usize) {
-        self.data.truncate(capacity);
-        self.data.shrink_to_fit();
-    }
+    /// Stored values higher than `capacity` may be dropped.
+    fn shrink_to(&mut self, capacity: usize);
+
+    /// Resizes the secondary map to `new_len`.
+    fn resize(&mut self, new_len: usize);
 
     /// Returns the maximum index the secondary map can contain without allocating.
-    #[inline]
-    pub fn capacity(&self) -> usize {
-        self.data.capacity()
-    }
+    fn capacity(&self) -> usize;
+
+    /// Immutably borrows the value at a `key`.
+    ///
+    /// Returns a borrow of the default value when no value has been set for the `key`.
+    fn get(&self, key: K) -> &V;
+
+    /// Sets the value at a `key`.
+    ///
+    /// When the value is not present, the secondary map is resized to accommodate it.
+    /// To avoid frequent resizing, use [`SecondaryMap::ensure_capacity`] to keep the
+    /// capacity of the secondary map in line with the size of the key space.
+    fn set(&mut self, key: K, val: V);
+
+    /// Takes the value at a `key`, leaving `default()` behind.
+    ///
+    /// When the value is not present, the secondary map is resized to accommodate it.
+    /// To avoid frequent resizing, use [`SecondaryMap::ensure_capacity`] to keep the
+    /// capacity of the secondary map in line with the size of the key space.
+    fn take(&mut self, key: K) -> V;
 
     /// Remove key `old` and optionally move to key `new`.
     ///
@@ -154,256 +69,175 @@ where
     ///
     /// [`PortGraph::set_num_ports`]: crate::portgraph::PortGraph::set_num_ports
     /// [`PortGraph::compact_nodes`]: crate::portgraph::PortGraph::compact_nodes
-    pub fn rekey(&mut self, old: K, new: Option<K>)
-    where
-        V: Default,
-    {
-        if old.into() < self.data.len() {
-            let val = mem::take(self.get_mut(old));
-            let Some(new) = new else { return };
-            if new.into() >= self.data.len() {
-                self.resize_for_get_mut(new.into() + 1);
-            }
-            self.data[new.into()] = val;
-        } else {
-            let Some(new) = new else { return };
-            if new.into() < self.data.len() {
-                self.data[new.into()] = Default::default();
-            }
-        }
-    }
-
-    /// Immutably borrows the value at a `key`.
-    ///
-    /// Returns a borrow of the default value when no value has been set for the `key`.
-    #[inline]
-    pub fn get(&self, key: K) -> &V {
-        self.data.get(key.into()).unwrap_or(&self.default)
-    }
-
-    /// Mutably borrows the value at a `key`.
-    ///
-    /// When the value is not present, the secondary map is resized to accommodate it.
-    /// To avoid frequent resizing, use [`SecondaryMap::ensure_capacity`] to keep the
-    /// capacity of the secondary map in line with the size of the key space.
-    #[inline]
-    pub fn get_mut(&mut self, key: K) -> &mut V {
-        let index = key.into();
-
-        if index >= self.data.len() {
-            self.resize_for_get_mut(index + 1);
-        }
-
-        &mut self.data[index]
-    }
-
-    /// Mutably borrows the value at a `key`.
-    ///
-    /// Returns `None` when the `key` is beyond the capacity of the secondary map.
-    #[inline]
-    pub fn try_get_mut(&mut self, key: K) -> Option<&mut V> {
-        self.data.get_mut(key.into())
-    }
-
-    /// Mutably borrows the values of a disjoint list of keys.
-    ///
-    /// Returns `None` when two keys coincide.
-    pub fn get_disjoint_mut<const N: usize>(&mut self, keys: [K; N]) -> Option<[&mut V; N]>
-    where
-        K: Eq,
-    {
-        // Ensure that there is enough capacity
-        if let Some(max_index) = keys.iter().map(|i| (*i).into()).max() {
-            if max_index >= self.data.len() {
-                self.resize_for_get_mut(max_index + 1);
-            }
-        };
-
-        // Collect pointers for all indices
-        let mut ptrs: [MaybeUninit<*mut V>; N] = [MaybeUninit::uninit(); N];
-
-        // NOTE: This is a quadratic check. That is not a problem for very small
-        // `N` but it would be nice if it could be avoided. See
-        // https://docs.rs/slotmap/latest/slotmap/struct.SlotMap.html#method.get_disjoint_mut
-        // for a linear time implementation. Unfortunately their trick is not
-        // applicable here since we do not have the extra tagging bit available.
-        let data = self.data.as_mut_ptr();
-        for (i, key) in keys.iter().enumerate() {
-            if keys[(i + 1)..].iter().any(|other| key == other) {
-                return None;
-            }
-
-            let offset = (*key).into();
-            if offset >= self.data.len() {
-                return None;
-            }
-            // SAFETY: The offset is within the bounds of the underlying array.
-            let ptr: *mut V = unsafe { data.add(offset) };
-            ptrs[i].write(ptr);
-        }
-
-        // SAFETY: The pointers come from valid borrows into the underlying
-        // array and we have checked their disjointness.
-        let refs = unsafe { ptrs.map(|p| &mut *p.assume_init()) };
-        Some(refs)
-    }
-
-    /// Must be called with `len` greater than `self.data.len()`.
-    #[cold]
-    fn resize_for_get_mut(&mut self, len: usize) {
-        self.data.resize(len, self.default.clone());
-    }
+    fn rekey(&mut self, old: K, new: Option<K>);
 
     /// Swaps the values of two keys.
-    ///
-    /// Allocates more memory when necessary to fit the keys.
+    fn swap(&mut self, key0: K, key1: K);
+
+    /// Returns an iterator over the non-default entries of the secondary map.
+    fn iter<'a>(&'a self) -> Self::Iter<'a>
+    where
+        K: 'a,
+        V: 'a;
+}
+
+impl<K> SecondaryMap<K, bool> for BitVec
+where
+    K: Into<usize> + TryFrom<usize>,
+{
+    type Iter<'a> = BitVecIter<'a, K> where Self: 'a, K: 'a;
+
     #[inline]
-    pub fn swap(&mut self, key0: K, key1: K) {
-        let index0 = key0.into();
-        let index1 = key1.into();
-        let max_index = std::cmp::max(index0, index1);
+    fn new() -> Self {
+        BitVec::new()
+    }
 
-        if max_index >= self.data.len() {
-            self.resize_for_get_mut(max_index + 1);
+    #[inline]
+    fn with_capacity(capacity: usize) -> Self {
+        BitVec::with_capacity(capacity)
+    }
+
+    #[inline]
+    fn default_value(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    fn ensure_capacity(&mut self, capacity: usize) {
+        BitVec::reserve(self, capacity.saturating_sub(self.capacity()));
+    }
+
+    #[inline]
+    fn shrink_to(&mut self, capacity: usize) {
+        BitVec::resize(self, capacity, false)
+    }
+
+    #[inline]
+    fn resize(&mut self, new_len: usize) {
+        BitVec::resize(self, new_len, false)
+    }
+
+    #[inline]
+    fn capacity(&self) -> usize {
+        BitVec::capacity(self)
+    }
+
+    #[inline]
+    fn get(&self, key: K) -> &bool {
+        // We can't return a reference to the internal bitflags, so we have to
+        // create static bools.
+        if BitSlice::get(self, key.into()).map_or(false, |f| *f) {
+            &true
+        } else {
+            &false
         }
+    }
 
-        self.data.swap(index0, index1);
+    #[inline]
+    fn set(&mut self, key: K, val: bool) {
+        let key = key.into();
+        if key >= BitVec::len(self) {
+            if val {
+                BitVec::resize(self, key + 1, false);
+                BitSlice::set(self, key, true);
+            }
+        } else {
+            BitSlice::set(self, key, val);
+        }
+    }
+
+    #[inline]
+    fn take(&mut self, key: K) -> bool {
+        let key = key.into();
+        if key >= BitVec::len(self) {
+            BitSlice::replace(self, key, false)
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    fn rekey(&mut self, old: K, new: Option<K>) {
+        let val = self.take(old);
+        if let Some(new) = new {
+            self.set(new, val);
+        }
+    }
+
+    #[inline]
+    fn swap(&mut self, key0: K, key1: K) {
+        let key0: usize = key0.into();
+        let key1: usize = key1.into();
+        let val0 = *self.get(key0);
+        let val1 = *self.get(key1);
+        if val0 != val1 {
+            self.set(key0, val1);
+            self.set(key1, val0);
+        }
+    }
+
+    #[inline]
+    fn iter<'a>(&'a self) -> Self::Iter<'a>
+    where
+        K: 'a,
+    {
+        BitVecIter {
+            iter: BitSlice::iter_ones(self),
+            phantom: std::marker::PhantomData,
+        }
     }
 }
 
-impl<K, V> Default for SecondaryMap<K, V>
+/// Iterator over non-default entries of a bit vector secondary map.
+#[derive(Debug, Clone, Default)]
+pub struct BitVecIter<'a, K> {
+    iter: IterOnes<'a, usize, bitvec::order::Lsb0>,
+    phantom: std::marker::PhantomData<K>,
+}
+
+impl<'a, K> Iterator for BitVecIter<'a, K>
 where
-    K: Into<usize> + Copy,
-    V: Clone + Default,
+    K: TryFrom<usize>,
 {
-    fn default() -> Self {
-        Self::new()
+    type Item = (K, &'a bool);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter
+            .next()
+            .map(|i| (i.try_into().ok().unwrap(), &true))
+    }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter
+            .nth(n)
+            .map(|i| (i.try_into().ok().unwrap(), &true))
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
     }
 }
 
-impl<K, V> Index<K> for SecondaryMap<K, V>
+impl<'a, K> DoubleEndedIterator for BitVecIter<'a, K>
 where
-    K: Into<usize> + Copy,
-    V: Clone,
+    K: TryFrom<usize>,
 {
-    type Output = V;
-
-    fn index(&self, key: K) -> &Self::Output {
-        self.get(key)
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter
+            .next_back()
+            .map(|i| (i.try_into().ok().unwrap(), &true))
     }
 }
 
-impl<K, V> IndexMut<K> for SecondaryMap<K, V>
-where
-    K: Into<usize> + Copy,
-    V: Clone,
-{
-    fn index_mut(&mut self, key: K) -> &mut Self::Output {
-        self.get_mut(key)
-    }
-}
+impl<'a, K> FusedIterator for BitVecIter<'a, K> where K: TryFrom<usize> {}
 
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_capacity() {
-        let mut map: SecondaryMap<usize, usize> = SecondaryMap::new();
-
-        assert_eq!(map.capacity(), 0);
-
-        map.ensure_capacity(10);
-        assert!(map.capacity() >= 10);
-
-        let prev_capacity = map.capacity();
-        map.ensure_capacity(5);
-        assert_eq!(map.capacity(), prev_capacity);
-
-        map.ensure_capacity(15);
-        assert!(map.capacity() >= 15);
-
-        map.shrink_to(5);
-        assert!(map.capacity() >= 5);
-
-        let prev_capacity = map.capacity();
-        map.shrink_to(10);
-        assert_eq!(map.capacity(), prev_capacity);
-    }
-
-    #[test]
-    fn test_get_mut() {
-        let mut map: SecondaryMap<usize, i32> = SecondaryMap::with_default(4);
-
-        let value = map.get_mut(0);
-        assert_eq!(value, &4);
-        *value = 1;
-        assert_eq!(map.get_mut(0), &1);
-
-        let value = map.try_get_mut(10);
-        assert_eq!(value, None);
-
-        let value = map.get_mut(10);
-        assert_eq!(value, &mut 4);
-        *value = 2;
-        assert_eq!(map.try_get_mut(10), Some(&mut 2));
-    }
-
-    #[test]
-    fn test_get_disjoint_mut() {
-        let mut map: SecondaryMap<usize, i32> = SecondaryMap::new();
-
-        let values = map.get_disjoint_mut([0, 1, 2]);
-        assert_eq!(values, Some([&mut 0, &mut 0, &mut 0]));
-        let values = values.unwrap();
-        *values[0] = 1;
-        *values[1] = 2;
-        *values[2] = 3;
-        assert_eq!(
-            map.get_disjoint_mut([0, 1, 2]),
-            Some([&mut 1, &mut 2, &mut 3])
-        );
-
-        let values = map.get_disjoint_mut([0, 1, 0]);
-        assert_eq!(values, None);
-    }
-
-    #[test]
-    fn test_swap() {
-        let mut map: SecondaryMap<usize, i32> = SecondaryMap::new();
-        map[0] = 0x10;
-        map[1] = 0x11;
-        map[3] = 0x13;
-
-        map.swap(0, 1);
-        assert_eq!(map[0], 0x11);
-        assert_eq!(map[1], 0x10);
-
-        map.swap(10, 3);
-        assert_eq!(map[3], 0);
-        assert_eq!(map[10], 0x13);
-    }
-
-    #[cfg(feature = "serde")]
-    #[test]
-    fn secondary_serialize() {
-        let mut map: SecondaryMap<usize, i32> = SecondaryMap::new();
-        assert_eq!(crate::portgraph::test::ser_roundtrip(&map), map);
-        map[0] = 0x10;
-        map[1] = 0x11;
-        map[3] = 0x13;
-        assert_eq!(crate::portgraph::test::ser_roundtrip(&map), map);
-    }
-
-    #[test]
-    fn eq_ignores_defaults() {
-        let mut a = SecondaryMap::<usize, usize>::new();
-        let mut b = SecondaryMap::<usize, usize>::new();
-        a[4] = 0;
-        assert_eq!(a, b);
-        b[42] = 0;
-        assert_eq!(a, b);
-        b[40] = 24;
-        assert_ne!(a, b);
-    }
-}
+// TODO: Implementations for HashSet, BTreeSet, HashMap, BTreeMap.

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -19,8 +19,6 @@ pub trait SecondaryMap<K, V> {
         V: 'a;
 
     /// Creates a new secondary map.
-    ///
-    /// This does not allocate any memory until a value is modified.
     fn new() -> Self;
 
     /// Creates a new secondary map with specified capacity.
@@ -49,17 +47,9 @@ pub trait SecondaryMap<K, V> {
     fn get(&self, key: K) -> &V;
 
     /// Sets the value at a `key`.
-    ///
-    /// When the value is not present, the secondary map is resized to accommodate it.
-    /// To avoid frequent resizing, use [`SecondaryMap::ensure_capacity`] to keep the
-    /// capacity of the secondary map in line with the size of the key space.
     fn set(&mut self, key: K, val: V);
 
     /// Takes the value at a `key`, leaving `default()` behind.
-    ///
-    /// When the value is not present, the secondary map is resized to accommodate it.
-    /// To avoid frequent resizing, use [`SecondaryMap::ensure_capacity`] to keep the
-    /// capacity of the secondary map in line with the size of the key space.
     fn take(&mut self, key: K) -> V;
 
     /// Remove key `old` and optionally move to key `new`.
@@ -149,7 +139,7 @@ where
     #[inline]
     fn take(&mut self, key: K) -> bool {
         let key = key.into();
-        if key >= BitVec::len(self) {
+        if key < BitVec::len(self) {
             BitSlice::replace(self, key, false)
         } else {
             false

--- a/src/unmanaged.rs
+++ b/src/unmanaged.rs
@@ -315,6 +315,9 @@ where
 {
     type Iter<'a> = UnmanagedIter<'a, K, V> where Self: 'a, K: 'a, V: 'a;
 
+    /// Creates a new secondary map.
+    ///
+    /// This does not allocate any memory until a value is modified.
     #[inline]
     fn new() -> Self {
         Self::with_default(Default::default())
@@ -359,6 +362,11 @@ where
         UnmanagedMap::get(self, key)
     }
 
+    /// Sets the value at a `key`.
+    ///
+    /// When the value is not present, the secondary map is resized to accommodate it.
+    /// To avoid frequent resizing, use [`SecondaryMap::ensure_capacity`] to keep the
+    /// capacity of the secondary map in line with the size of the key space.
     #[inline]
     fn set(&mut self, key: K, val: V) {
         self[key] = val;

--- a/src/unmanaged.rs
+++ b/src/unmanaged.rs
@@ -1,0 +1,550 @@
+//! A dense key-value map used to store graph weights.
+//!
+//! This map does not track valid indices and does not allocate any memory until
+//! a value is modified, returning references to the default value instead.
+//!
+//! This structure is intended to be used alongside [`PortGraph`], as it does
+//! not keep track of the valid keys.
+//!
+//! For simple cases where the nodes and ports have a single weight each, see
+//! [`Weights`].
+//!
+//! [`PortGraph`]: crate::portgraph::PortGraph
+//! [`Weights`]: crate::weights::Weights
+//!
+//! # Example
+//!
+//! ```
+//! # use portgraph::{PortGraph, NodeIndex, PortIndex};
+//! # use portgraph::unmanaged::UnmanagedMap;
+//!
+//! let mut graph = PortGraph::new();
+//! let mut node_weights = UnmanagedMap::<NodeIndex, usize>::new();
+//! let mut port_weights = UnmanagedMap::<PortIndex, isize>::new();
+//!
+//! // The weights must be set manually.
+//! let node = graph.add_node(2, 2);
+//! let [in0, in1, ..] = graph.inputs(node).collect::<Vec<_>>()[..] else { unreachable!() };
+//! let [out0, out1, ..] = graph.outputs(node).collect::<Vec<_>>()[..] else { unreachable!() };
+//! node_weights[node] = 42;
+//! port_weights[in1] = 2;
+//! port_weights[out0] = -1;
+//! port_weights[out1] = -2;
+//!
+//! /// Unset weights return the default value.
+//! assert_eq!(port_weights[in0], 0);
+//!
+//! // Graph operations that modify the keys use callbacks to update the weights.
+//! graph.set_num_ports(node, 1, 3, |old, new| {if let Some(new) = new {port_weights.swap(old, new);}});
+//!
+//! // The map does not track item removals, but the user can shrink the map manually.
+//! graph.remove_node(node);
+//! node_weights.shrink_to(graph.node_count());
+//! port_weights.shrink_to(graph.port_count());
+//!
+//! ```
+
+use std::{
+    cmp::Ordering,
+    iter::{Enumerate, FusedIterator},
+    marker::PhantomData,
+    mem::{self, MaybeUninit},
+    ops::{Index, IndexMut},
+    slice,
+};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::SecondaryMap;
+
+/// A dense map from keys to values with default fallbacks.
+///
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct UnmanagedMap<K, V> {
+    data: Vec<V>,
+    phantom: PhantomData<K>,
+    default: V,
+}
+
+impl<K: PartialEq, V: PartialEq> PartialEq for UnmanagedMap<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.default != other.default {
+            return false;
+        }
+        let common_len = std::cmp::min(self.data.len(), other.data.len());
+        self.data[..common_len] == other.data[..common_len]
+            && self.data[common_len..].iter().all(|v| v == &self.default)
+            && other.data[common_len..].iter().all(|v| v == &other.default)
+    }
+}
+
+impl<K, V> UnmanagedMap<K, V>
+where
+    K: Into<usize> + Copy,
+    V: Clone,
+{
+    /// Creates a new secondary map.
+    ///
+    /// This does not allocate any memory until a value is modified.
+    #[inline]
+    pub fn new() -> Self
+    where
+        V: Default,
+    {
+        Self::with_default(Default::default())
+    }
+
+    /// Creates a new secondary map, specifying the default element.
+    ///
+    /// This does not allocate any memory until a value is modified.
+    #[inline]
+    pub fn with_default(default: V) -> Self {
+        Self {
+            data: Vec::new(),
+            phantom: PhantomData,
+            default,
+        }
+    }
+
+    /// Creates a new secondary map with specified capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self
+    where
+        V: Default,
+    {
+        Self::with_capacity_and_default(capacity, Default::default())
+    }
+
+    /// Creates a new secondary map with specified capacity and default element.
+    #[inline]
+    pub fn with_capacity_and_default(capacity: usize, default: V) -> Self {
+        Self {
+            data: Vec::with_capacity(capacity),
+            phantom: PhantomData,
+            default,
+        }
+    }
+
+    /// Increases the capacity of the secondary map to `capacity`.
+    ///
+    /// Does nothing when the capacity of the secondary map is already sufficient.
+    pub fn ensure_capacity(&mut self, capacity: usize) {
+        if capacity > self.data.capacity() {
+            self.data.reserve(capacity - self.data.capacity());
+            self.data.resize(capacity, self.default.clone());
+        }
+    }
+
+    /// Reduces the capacity of the secondary map to `capacity`.
+    /// Stored values higher than `capacity` are dropped.
+    ///
+    /// Does nothing when the capacity of the secondary map is already lower.
+    pub fn shrink_to(&mut self, capacity: usize) {
+        self.data.truncate(capacity);
+        self.data.shrink_to_fit();
+    }
+
+    /// Returns the maximum index the secondary map can contain without allocating.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.data.capacity()
+    }
+
+    /// Remove key `old` and optionally move to key `new`.
+    ///
+    /// This method is useful for rekey callbacks such as in
+    /// [`PortGraph::set_num_ports`] and [`PortGraph::compact_nodes`].
+    ///
+    /// [`PortGraph::set_num_ports`]: crate::portgraph::PortGraph::set_num_ports
+    /// [`PortGraph::compact_nodes`]: crate::portgraph::PortGraph::compact_nodes
+    pub fn rekey(&mut self, old: K, new: Option<K>)
+    where
+        V: Default,
+    {
+        if old.into() < self.data.len() {
+            let val = mem::take(self.get_mut(old));
+            let Some(new) = new else { return };
+            if new.into() >= self.data.len() {
+                self.resize_for_get_mut(new.into() + 1);
+            }
+            self.data[new.into()] = val;
+        } else {
+            let Some(new) = new else { return };
+            if new.into() < self.data.len() {
+                self.data[new.into()] = Default::default();
+            }
+        }
+    }
+
+    /// Immutably borrows the value at a `key`.
+    ///
+    /// Returns a borrow of the default value when no value has been set for the `key`.
+    #[inline]
+    pub fn get(&self, key: K) -> &V {
+        self.data.get(key.into()).unwrap_or(&self.default)
+    }
+
+    /// Mutably borrows the value at a `key`.
+    ///
+    /// When the value is not present, the secondary map is resized to accommodate it.
+    /// To avoid frequent resizing, use [`SecondaryMap::ensure_capacity`] to keep the
+    /// capacity of the secondary map in line with the size of the key space.
+    #[inline]
+    pub fn get_mut(&mut self, key: K) -> &mut V {
+        let index = key.into();
+
+        if index >= self.data.len() {
+            self.resize_for_get_mut(index + 1);
+        }
+
+        &mut self.data[index]
+    }
+
+    /// Mutably borrows the value at a `key`.
+    ///
+    /// Returns `None` when the `key` is beyond the capacity of the secondary map.
+    #[inline]
+    pub fn try_get_mut(&mut self, key: K) -> Option<&mut V> {
+        self.data.get_mut(key.into())
+    }
+
+    /// Mutably borrows the values of a disjoint list of keys.
+    ///
+    /// Returns `None` when two keys coincide.
+    pub fn get_disjoint_mut<const N: usize>(&mut self, keys: [K; N]) -> Option<[&mut V; N]>
+    where
+        K: Eq,
+    {
+        // Ensure that there is enough capacity
+        if let Some(max_index) = keys.iter().map(|i| (*i).into()).max() {
+            if max_index >= self.data.len() {
+                self.resize_for_get_mut(max_index + 1);
+            }
+        };
+
+        // Collect pointers for all indices
+        let mut ptrs: [MaybeUninit<*mut V>; N] = [MaybeUninit::uninit(); N];
+
+        // NOTE: This is a quadratic check. That is not a problem for very small
+        // `N` but it would be nice if it could be avoided. See
+        // https://docs.rs/slotmap/latest/slotmap/struct.SlotMap.html#method.get_disjoint_mut
+        // for a linear time implementation. Unfortunately their trick is not
+        // applicable here since we do not have the extra tagging bit available.
+        let data = self.data.as_mut_ptr();
+        for (i, key) in keys.iter().enumerate() {
+            if keys[(i + 1)..].iter().any(|other| key == other) {
+                return None;
+            }
+
+            let offset = (*key).into();
+            if offset >= self.data.len() {
+                return None;
+            }
+            // SAFETY: The offset is within the bounds of the underlying array.
+            let ptr: *mut V = unsafe { data.add(offset) };
+            ptrs[i].write(ptr);
+        }
+
+        // SAFETY: The pointers come from valid borrows into the underlying
+        // array and we have checked their disjointness.
+        let refs = unsafe { ptrs.map(|p| &mut *p.assume_init()) };
+        Some(refs)
+    }
+
+    /// Must be called with `len` greater than `self.data.len()`.
+    #[cold]
+    fn resize_for_get_mut(&mut self, len: usize) {
+        self.data.resize(len, self.default.clone());
+    }
+
+    /// Swaps the values of two keys.
+    ///
+    /// Allocates more memory when necessary to fit the keys.
+    #[inline]
+    pub fn swap(&mut self, key0: K, key1: K) {
+        let index0 = key0.into();
+        let index1 = key1.into();
+        let max_index = std::cmp::max(index0, index1);
+
+        if max_index >= self.data.len() {
+            self.resize_for_get_mut(max_index + 1);
+        }
+
+        self.data.swap(index0, index1);
+    }
+}
+
+impl<K, V> Default for UnmanagedMap<K, V>
+where
+    K: Into<usize> + Copy,
+    V: Clone + Default,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> Index<K> for UnmanagedMap<K, V>
+where
+    K: Into<usize> + Copy,
+    V: Clone,
+{
+    type Output = V;
+
+    fn index(&self, key: K) -> &Self::Output {
+        self.get(key)
+    }
+}
+
+impl<K, V> IndexMut<K> for UnmanagedMap<K, V>
+where
+    K: Into<usize> + Copy,
+    V: Clone,
+{
+    fn index_mut(&mut self, key: K) -> &mut Self::Output {
+        self.get_mut(key)
+    }
+}
+
+impl<K, V> SecondaryMap<K, V> for UnmanagedMap<K, V>
+where
+    K: Into<usize> + TryFrom<usize> + Copy,
+    V: Clone + Default,
+{
+    type Iter<'a> = UnmanagedIter<'a, K, V> where Self: 'a, K: 'a, V: 'a;
+
+    #[inline]
+    fn new() -> Self {
+        Self::with_default(Default::default())
+    }
+
+    #[inline]
+    fn with_capacity(capacity: usize) -> Self {
+        Self::with_capacity_and_default(capacity, Default::default())
+    }
+
+    #[inline]
+    fn default_value(&self) -> V {
+        self.default.clone()
+    }
+
+    #[inline]
+    fn ensure_capacity(&mut self, capacity: usize) {
+        UnmanagedMap::ensure_capacity(self, capacity)
+    }
+
+    #[inline]
+    fn shrink_to(&mut self, capacity: usize) {
+        UnmanagedMap::shrink_to(self, capacity)
+    }
+
+    #[inline]
+    fn resize(&mut self, new_len: usize) {
+        match self.data.len().cmp(&new_len) {
+            Ordering::Less => self.ensure_capacity(new_len),
+            Ordering::Greater => self.shrink_to(new_len),
+            _ => {}
+        }
+    }
+
+    #[inline]
+    fn capacity(&self) -> usize {
+        UnmanagedMap::capacity(self)
+    }
+
+    #[inline]
+    fn get(&self, key: K) -> &V {
+        UnmanagedMap::get(self, key)
+    }
+
+    #[inline]
+    fn set(&mut self, key: K, val: V) {
+        self[key] = val;
+    }
+
+    #[inline]
+    fn take(&mut self, key: K) -> V {
+        let default = self.default.clone();
+        mem::replace(&mut self[key], default)
+    }
+
+    #[inline]
+    fn rekey(&mut self, old: K, new: Option<K>) {
+        UnmanagedMap::rekey(self, old, new)
+    }
+
+    #[inline]
+    fn swap(&mut self, key0: K, key1: K) {
+        UnmanagedMap::swap(self, key0, key1)
+    }
+
+    fn iter<'a>(&'a self) -> Self::Iter<'a>
+    where
+        K: 'a,
+        V: 'a,
+    {
+        UnmanagedIter {
+            iter: self.data.iter().enumerate(),
+            phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+/// Iterator over non-default entries of an unmanaged map.
+#[derive(Debug, Clone)]
+pub struct UnmanagedIter<'a, K, V> {
+    iter: Enumerate<slice::Iter<'a, V>>,
+    phantom: std::marker::PhantomData<K>,
+}
+
+impl<'a, K, V> Iterator for UnmanagedIter<'a, K, V>
+where
+    K: TryFrom<usize>,
+{
+    type Item = (K, &'a V);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter
+            .next()
+            .map(|(key, value)| (key.try_into().ok().unwrap(), value))
+    }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter
+            .nth(n)
+            .map(|(key, value)| (key.try_into().ok().unwrap(), value))
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a, K, V> DoubleEndedIterator for UnmanagedIter<'a, K, V>
+where
+    K: TryFrom<usize>,
+{
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter
+            .next_back()
+            .map(|(key, value)| (key.try_into().ok().unwrap(), value))
+    }
+}
+
+impl<'a, K, V> FusedIterator for UnmanagedIter<'a, K, V> where K: TryFrom<usize> {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_capacity() {
+        let mut map: UnmanagedMap<usize, usize> = UnmanagedMap::new();
+
+        assert_eq!(map.capacity(), 0);
+
+        map.ensure_capacity(10);
+        assert!(map.capacity() >= 10);
+
+        let prev_capacity = map.capacity();
+        map.ensure_capacity(5);
+        assert_eq!(map.capacity(), prev_capacity);
+
+        map.ensure_capacity(15);
+        assert!(map.capacity() >= 15);
+
+        map.shrink_to(5);
+        assert!(map.capacity() >= 5);
+
+        let prev_capacity = map.capacity();
+        map.shrink_to(10);
+        assert_eq!(map.capacity(), prev_capacity);
+    }
+
+    #[test]
+    fn test_get_mut() {
+        let mut map: UnmanagedMap<usize, i32> = UnmanagedMap::with_default(4);
+
+        let value = map.get_mut(0);
+        assert_eq!(value, &4);
+        *value = 1;
+        assert_eq!(map.get_mut(0), &1);
+
+        let value = map.try_get_mut(10);
+        assert_eq!(value, None);
+
+        let value = map.get_mut(10);
+        assert_eq!(value, &mut 4);
+        *value = 2;
+        assert_eq!(map.try_get_mut(10), Some(&mut 2));
+    }
+
+    #[test]
+    fn test_get_disjoint_mut() {
+        let mut map: UnmanagedMap<usize, i32> = UnmanagedMap::new();
+
+        let values = map.get_disjoint_mut([0, 1, 2]);
+        assert_eq!(values, Some([&mut 0, &mut 0, &mut 0]));
+        let values = values.unwrap();
+        *values[0] = 1;
+        *values[1] = 2;
+        *values[2] = 3;
+        assert_eq!(
+            map.get_disjoint_mut([0, 1, 2]),
+            Some([&mut 1, &mut 2, &mut 3])
+        );
+
+        let values = map.get_disjoint_mut([0, 1, 0]);
+        assert_eq!(values, None);
+    }
+
+    #[test]
+    fn test_swap() {
+        let mut map: UnmanagedMap<usize, i32> = UnmanagedMap::new();
+        map[0] = 0x10;
+        map[1] = 0x11;
+        map[3] = 0x13;
+
+        map.swap(0, 1);
+        assert_eq!(map[0], 0x11);
+        assert_eq!(map[1], 0x10);
+
+        map.swap(10, 3);
+        assert_eq!(map[3], 0);
+        assert_eq!(map[10], 0x13);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn secondary_serialize() {
+        let mut map: UnmanagedMap<usize, i32> = UnmanagedMap::new();
+        assert_eq!(crate::portgraph::test::ser_roundtrip(&map), map);
+        map[0] = 0x10;
+        map[1] = 0x11;
+        map[3] = 0x13;
+        assert_eq!(crate::portgraph::test::ser_roundtrip(&map), map);
+    }
+
+    #[test]
+    fn eq_ignores_defaults() {
+        let mut a = UnmanagedMap::<usize, usize>::new();
+        let mut b = UnmanagedMap::<usize, usize>::new();
+        a[4] = 0;
+        assert_eq!(a, b);
+        b[42] = 0;
+        assert_eq!(a, b);
+        b[40] = 24;
+        assert_ne!(a, b);
+    }
+}

--- a/src/unmanaged.rs
+++ b/src/unmanaged.rs
@@ -16,11 +16,11 @@
 //!
 //! ```
 //! # use portgraph::{PortGraph, NodeIndex, PortIndex};
-//! # use portgraph::unmanaged::UnmanagedMap;
+//! # use portgraph::unmanaged::UnmanagedDenseMap;
 //!
 //! let mut graph = PortGraph::new();
-//! let mut node_weights = UnmanagedMap::<NodeIndex, usize>::new();
-//! let mut port_weights = UnmanagedMap::<PortIndex, isize>::new();
+//! let mut node_weights = UnmanagedDenseMap::<NodeIndex, usize>::new();
+//! let mut port_weights = UnmanagedDenseMap::<PortIndex, isize>::new();
 //!
 //! // The weights must be set manually.
 //! let node = graph.add_node(2, 2);
@@ -62,13 +62,13 @@ use crate::SecondaryMap;
 ///
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-pub struct UnmanagedMap<K, V> {
+pub struct UnmanagedDenseMap<K, V> {
     data: Vec<V>,
     phantom: PhantomData<K>,
     default: V,
 }
 
-impl<K: PartialEq, V: PartialEq> PartialEq for UnmanagedMap<K, V> {
+impl<K: PartialEq, V: PartialEq> PartialEq for UnmanagedDenseMap<K, V> {
     fn eq(&self, other: &Self) -> bool {
         if self.default != other.default {
             return false;
@@ -80,7 +80,7 @@ impl<K: PartialEq, V: PartialEq> PartialEq for UnmanagedMap<K, V> {
     }
 }
 
-impl<K, V> UnmanagedMap<K, V>
+impl<K, V> UnmanagedDenseMap<K, V>
 where
     K: Into<usize> + Copy,
     V: Clone,
@@ -276,7 +276,7 @@ where
     }
 }
 
-impl<K, V> Default for UnmanagedMap<K, V>
+impl<K, V> Default for UnmanagedDenseMap<K, V>
 where
     K: Into<usize> + Copy,
     V: Clone + Default,
@@ -286,7 +286,7 @@ where
     }
 }
 
-impl<K, V> Index<K> for UnmanagedMap<K, V>
+impl<K, V> Index<K> for UnmanagedDenseMap<K, V>
 where
     K: Into<usize> + Copy,
     V: Clone,
@@ -298,7 +298,7 @@ where
     }
 }
 
-impl<K, V> IndexMut<K> for UnmanagedMap<K, V>
+impl<K, V> IndexMut<K> for UnmanagedDenseMap<K, V>
 where
     K: Into<usize> + Copy,
     V: Clone,
@@ -308,7 +308,7 @@ where
     }
 }
 
-impl<K, V> SecondaryMap<K, V> for UnmanagedMap<K, V>
+impl<K, V> SecondaryMap<K, V> for UnmanagedDenseMap<K, V>
 where
     K: Into<usize> + TryFrom<usize> + Copy,
     V: Clone + Default,
@@ -335,12 +335,12 @@ where
 
     #[inline]
     fn ensure_capacity(&mut self, capacity: usize) {
-        UnmanagedMap::ensure_capacity(self, capacity)
+        UnmanagedDenseMap::ensure_capacity(self, capacity)
     }
 
     #[inline]
     fn shrink_to(&mut self, capacity: usize) {
-        UnmanagedMap::shrink_to(self, capacity)
+        UnmanagedDenseMap::shrink_to(self, capacity)
     }
 
     #[inline]
@@ -354,12 +354,12 @@ where
 
     #[inline]
     fn capacity(&self) -> usize {
-        UnmanagedMap::capacity(self)
+        UnmanagedDenseMap::capacity(self)
     }
 
     #[inline]
     fn get(&self, key: K) -> &V {
-        UnmanagedMap::get(self, key)
+        UnmanagedDenseMap::get(self, key)
     }
 
     /// Sets the value at a `key`.
@@ -380,12 +380,12 @@ where
 
     #[inline]
     fn rekey(&mut self, old: K, new: Option<K>) {
-        UnmanagedMap::rekey(self, old, new)
+        UnmanagedDenseMap::rekey(self, old, new)
     }
 
     #[inline]
     fn swap(&mut self, key0: K, key1: K) {
-        UnmanagedMap::swap(self, key0, key1)
+        UnmanagedDenseMap::swap(self, key0, key1)
     }
 
     fn iter<'a>(&'a self) -> Self::Iter<'a>
@@ -458,7 +458,7 @@ mod test {
 
     #[test]
     fn test_capacity() {
-        let mut map: UnmanagedMap<usize, usize> = UnmanagedMap::new();
+        let mut map: UnmanagedDenseMap<usize, usize> = UnmanagedDenseMap::new();
 
         assert_eq!(map.capacity(), 0);
 
@@ -482,7 +482,7 @@ mod test {
 
     #[test]
     fn test_get_mut() {
-        let mut map: UnmanagedMap<usize, i32> = UnmanagedMap::with_default(4);
+        let mut map: UnmanagedDenseMap<usize, i32> = UnmanagedDenseMap::with_default(4);
 
         let value = map.get_mut(0);
         assert_eq!(value, &4);
@@ -500,7 +500,7 @@ mod test {
 
     #[test]
     fn test_get_disjoint_mut() {
-        let mut map: UnmanagedMap<usize, i32> = UnmanagedMap::new();
+        let mut map: UnmanagedDenseMap<usize, i32> = UnmanagedDenseMap::new();
 
         let values = map.get_disjoint_mut([0, 1, 2]);
         assert_eq!(values, Some([&mut 0, &mut 0, &mut 0]));
@@ -519,7 +519,7 @@ mod test {
 
     #[test]
     fn test_swap() {
-        let mut map: UnmanagedMap<usize, i32> = UnmanagedMap::new();
+        let mut map: UnmanagedDenseMap<usize, i32> = UnmanagedDenseMap::new();
         map[0] = 0x10;
         map[1] = 0x11;
         map[3] = 0x13;
@@ -536,7 +536,7 @@ mod test {
     #[cfg(feature = "serde")]
     #[test]
     fn secondary_serialize() {
-        let mut map: UnmanagedMap<usize, i32> = UnmanagedMap::new();
+        let mut map: UnmanagedDenseMap<usize, i32> = UnmanagedDenseMap::new();
         assert_eq!(crate::portgraph::test::ser_roundtrip(&map), map);
         map[0] = 0x10;
         map[1] = 0x11;
@@ -546,8 +546,8 @@ mod test {
 
     #[test]
     fn eq_ignores_defaults() {
-        let mut a = UnmanagedMap::<usize, usize>::new();
-        let mut b = UnmanagedMap::<usize, usize>::new();
+        let mut a = UnmanagedDenseMap::<usize, usize>::new();
+        let mut b = UnmanagedDenseMap::<usize, usize>::new();
         a[4] = 0;
         assert_eq!(a, b);
         b[42] = 0;

--- a/src/unmanaged.rs
+++ b/src/unmanaged.rs
@@ -339,11 +339,6 @@ where
     }
 
     #[inline]
-    fn shrink_to(&mut self, capacity: usize) {
-        UnmanagedDenseMap::shrink_to(self, capacity)
-    }
-
-    #[inline]
     fn resize(&mut self, new_len: usize) {
         match self.data.len().cmp(&new_len) {
             Ordering::Less => self.ensure_capacity(new_len),

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -6,6 +6,7 @@
 //! is intended to be used alongside [`PortGraph`].
 //!
 //! [`PortGraph`]: crate::portgraph::PortGraph
+//! [`SecondaryMap`]: crate::SecondaryMap
 //!
 //! # Example
 //!
@@ -49,7 +50,7 @@ use serde::{Deserialize, Serialize};
 use crate::{NodeIndex, PortIndex, UnmanagedMap};
 
 /// Graph component that encodes node and port weights.
-/// Based on two [`SecondaryMap`] containers.
+/// Based on two [`UnmanagedMap`] containers.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Weights<N, P> {

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -47,7 +47,7 @@ use std::ops::{Index, IndexMut};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{NodeIndex, PortIndex, UnmanagedMap};
+use crate::{NodeIndex, PortIndex, UnmanagedDenseMap};
 
 /// Graph component that encodes node and port weights.
 /// Based on two [`UnmanagedMap`] containers.
@@ -55,9 +55,9 @@ use crate::{NodeIndex, PortIndex, UnmanagedMap};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Weights<N, P> {
     /// Node weights.
-    pub nodes: UnmanagedMap<NodeIndex, N>,
+    pub nodes: UnmanagedDenseMap<NodeIndex, N>,
     /// Port weights.
-    pub ports: UnmanagedMap<PortIndex, P>,
+    pub ports: UnmanagedDenseMap<PortIndex, P>,
 }
 
 impl<N, P> Weights<N, P>
@@ -71,8 +71,8 @@ where
     #[inline]
     pub fn new() -> Self {
         Self {
-            nodes: UnmanagedMap::new(),
-            ports: UnmanagedMap::new(),
+            nodes: UnmanagedDenseMap::new(),
+            ports: UnmanagedDenseMap::new(),
         }
     }
 
@@ -80,8 +80,8 @@ where
     #[inline]
     pub fn with_capacity(nodes: usize, ports: usize) -> Self {
         Self {
-            nodes: UnmanagedMap::with_capacity(nodes),
-            ports: UnmanagedMap::with_capacity(ports),
+            nodes: UnmanagedDenseMap::with_capacity(nodes),
+            ports: UnmanagedDenseMap::with_capacity(ports),
         }
     }
 }
@@ -94,8 +94,8 @@ where
     #[inline]
     fn default() -> Self {
         Self {
-            nodes: UnmanagedMap::new(),
-            ports: UnmanagedMap::new(),
+            nodes: UnmanagedDenseMap::new(),
+            ports: UnmanagedDenseMap::new(),
         }
     }
 }

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -46,7 +46,7 @@ use std::ops::{Index, IndexMut};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{NodeIndex, PortIndex, SecondaryMap};
+use crate::{NodeIndex, PortIndex, UnmanagedMap};
 
 /// Graph component that encodes node and port weights.
 /// Based on two [`SecondaryMap`] containers.
@@ -54,9 +54,9 @@ use crate::{NodeIndex, PortIndex, SecondaryMap};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Weights<N, P> {
     /// Node weights.
-    pub nodes: SecondaryMap<NodeIndex, N>,
+    pub nodes: UnmanagedMap<NodeIndex, N>,
     /// Port weights.
-    pub ports: SecondaryMap<PortIndex, P>,
+    pub ports: UnmanagedMap<PortIndex, P>,
 }
 
 impl<N, P> Weights<N, P>
@@ -70,8 +70,8 @@ where
     #[inline]
     pub fn new() -> Self {
         Self {
-            nodes: SecondaryMap::new(),
-            ports: SecondaryMap::new(),
+            nodes: UnmanagedMap::new(),
+            ports: UnmanagedMap::new(),
         }
     }
 
@@ -79,8 +79,8 @@ where
     #[inline]
     pub fn with_capacity(nodes: usize, ports: usize) -> Self {
         Self {
-            nodes: SecondaryMap::with_capacity(nodes),
-            ports: SecondaryMap::with_capacity(ports),
+            nodes: UnmanagedMap::with_capacity(nodes),
+            ports: UnmanagedMap::with_capacity(ports),
         }
     }
 }
@@ -93,8 +93,8 @@ where
     #[inline]
     fn default() -> Self {
         Self {
-            nodes: SecondaryMap::new(),
-            ports: SecondaryMap::new(),
+            nodes: UnmanagedMap::new(),
+            ports: UnmanagedMap::new(),
         }
     }
 }

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -50,7 +50,7 @@ use serde::{Deserialize, Serialize};
 use crate::{NodeIndex, PortIndex, UnmanagedDenseMap};
 
 /// Graph component that encodes node and port weights.
-/// Based on two [`UnmanagedMap`] containers.
+/// Based on two [`UnmanagedDenseMap`] containers.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Weights<N, P> {


### PR DESCRIPTION
This is a big breaking change that will give us more flexibility when managing secondary data on a portgraph.

It adds a `SecondaryMap` trait that encapsulates the common interfaces we use when managing node and port data.
We can then implement that trait on different structures like the old `SecondaryMap` (now renamed `UnmanagedMap`), bit vec for boolean storage, and any {Hash,BTree}{Set,Map}. This closes #46.

With this, we can add a `Map` generic parameter to `DominatorTree` and `TopoSort` that lets us use more efficient structures when we do not traverse the full graph. This closes #31.

Also:
- Renames the old SecondaryMap struct as "UnmanagedMap".
- Implements SecondaryMap for BitVec.
- Uses the trait in Dominators and TopoSort to avoid wasting memory when doing partial traversals.


There's a TODO to implement SecondaryMap for sparse containers (hash and BTree), but those can be done in another non-breaking PR.

Note that `unmanaged.rs` is mostly the old contents of `secondary.rs`, but git didn't pick up the renaming.