### PR TITLE
Pass the old link of a port when it is removed

### DIFF
--- a/src/portgraph/iter.rs
+++ b/src/portgraph/iter.rs
@@ -151,6 +151,12 @@ impl<'a> Iterator for Ports<'a> {
     }
 }
 
+impl<'a> ExactSizeIterator for Ports<'a> {
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
 impl<'a> DoubleEndedIterator for Ports<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
         while let Some((index, port_entry)) = self.iter.next_back() {

--- a/src/unmanaged.rs
+++ b/src/unmanaged.rs
@@ -35,7 +35,9 @@
 //! assert_eq!(port_weights[in0], 0);
 //!
 //! // Graph operations that modify the keys use callbacks to update the weights.
-//! graph.set_num_ports(node, 1, 3, |old, new| {if let Some(new) = new {port_weights.swap(old, new);}});
+//! graph.set_num_ports(node, 1, 3, |old, op| {
+//!     op.new_index().map(|new| port_weights.swap(old, new));
+//! });
 //!
 //! // The map does not track item removals, but the user can shrink the map manually.
 //! graph.remove_node(node);

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -29,10 +29,8 @@
 //! assert_eq!(weights[in0], 0);
 //!
 //! // Graph operations that modify the keys have callbacks to update the weights.
-//! graph.set_num_ports(node, 1, 3, |old, new| {
-//!     if let Some(new) = new {
-//!         weights.ports.swap(old, new);
-//!     }
+//! graph.set_num_ports(node, 1, 3, |old, op| {
+//!     op.new_index().map(|new| weights.ports.swap(old, new));
 //! });
 //!
 //! // The map does not track item removals, but the user can shrink it manually.


### PR DESCRIPTION
Adds a `PortOperation` to clarify when a port is removed vs when it's moved.

drive-by: add missing `ExactSizeIterator` to `Ports`