### PR TITLE
Implement SecondaryMap for HashSet and HashMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ bitvec = "1.0.1"
 serde = { version = "1.0.152", features = ["derive"], optional = true}
 proptest = { version = "1.1.0", optional = true }
 rand = { version = "0.8.5", optional = true }
+const-default = { version = "1.0.0", default-features = false, features = ["derive"]}
 
 [features]
 pyo3 = ["dep:pyo3"]

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -54,7 +54,7 @@ use std::mem::{replace, take};
 use thiserror::Error;
 
 use crate::unmanaged::UnmanagedDenseMap;
-use crate::NodeIndex;
+use crate::{impl_static_default, NodeIndex};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -486,6 +486,8 @@ impl Default for NodeData {
         Self::new()
     }
 }
+
+impl_static_default!(NodeData, NodeData::new());
 
 /// Iterator created by [`Hierarchy::children`].
 #[derive(Clone)]

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -49,12 +49,13 @@
 //! hierarchy.shrink_to(graph.node_count());
 //! ```
 
+use const_default::ConstDefault;
 use std::iter::FusedIterator;
 use std::mem::{replace, take};
 use thiserror::Error;
 
 use crate::unmanaged::UnmanagedDenseMap;
-use crate::{impl_static_default, NodeIndex};
+use crate::NodeIndex;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -457,7 +458,7 @@ impl Hierarchy {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, ConstDefault)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 struct NodeData {
     /// The first and last child of the node, if any.
@@ -469,25 +470,6 @@ struct NodeData {
     /// The siblings of a node, if any.
     siblings: [Option<NodeIndex>; 2],
 }
-
-impl NodeData {
-    pub const fn new() -> Self {
-        Self {
-            children: None,
-            children_count: 0u32,
-            parent: None,
-            siblings: [None; 2],
-        }
-    }
-}
-
-impl Default for NodeData {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl_static_default!(NodeData, NodeData::new());
 
 /// Iterator created by [`Hierarchy::children`].
 #[derive(Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@
 //!   graph component structures.
 //! - `pyo3` enables Python bindings.
 //!
+use const_default::ConstDefault;
 use std::num::{NonZeroU16, NonZeroU32};
 use thiserror::Error;
 
@@ -198,14 +199,13 @@ impl std::fmt::Debug for NodeIndex {
     }
 }
 
-impl_static_default!(
-    NodeIndex,
-    match NodeIndex::try_from_usize(0) {
+impl ConstDefault for NodeIndex {
+    const DEFAULT: Self = match NodeIndex::try_from_usize(0) {
         Ok(index) => index,
         // Zero is always a valid index
         Err(_) => unreachable!(),
-    }
-);
+    };
+}
 
 /// Index of a port within a `PortGraph`.
 ///
@@ -278,14 +278,13 @@ impl Default for PortIndex {
     }
 }
 
-impl_static_default!(
-    PortIndex,
-    match PortIndex::try_from_usize(0) {
+impl ConstDefault for PortIndex {
+    const DEFAULT: Self = match PortIndex::try_from_usize(0) {
         Ok(index) => index,
         // Zero is always a valid index
         Err(_) => unreachable!(),
-    }
-);
+    };
+}
 
 /// Error indicating a `NodeIndex`, `PortIndex`, or `Direction` is too large.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
@@ -368,4 +367,6 @@ impl std::fmt::Debug for PortOffset {
     }
 }
 
-impl_static_default!(PortOffset, PortOffset::new_outgoing(0));
+impl ConstDefault for PortOffset {
+    const DEFAULT: Self = PortOffset::new_outgoing(0);
+}


### PR DESCRIPTION
Closes #55

The changes are mostly filling the trait impls.
~I had to add the `StaticDefault` trait because `SecondaryMap` needs to always be able to return a reference to a default value.~ (Note: Replaced with `ConstDefault` from the `const_default` crate).