### PR TITLE
serialize NodeIndex as 0-indexed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,8 +220,29 @@ impl std::fmt::Debug for NodeIndex {
 /// as a `PortIndex` by itself.
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct PortIndex(NonZeroU32);
+
+#[cfg(feature = "serde")]
+impl Serialize for PortIndex {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.index().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for PortIndex {
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        usize::deserialize(deserializer).map(PortIndex::new)
+    }
+}
 
 impl PortIndex {
     /// Maximum allowed index. The higher bit is reserved for efficient encoding of the port graph.


### PR DESCRIPTION
Direct serialization stores the underlying NonZeroU32 which can be confusing