### PR TITLE
Implement View traits for Portgraph and Multiportgraph

### DIFF
--- a/benches/benchmarks/generators.rs
+++ b/benches/benchmarks/generators.rs
@@ -1,4 +1,4 @@
-use portgraph::{Hierarchy, NodeIndex, PortGraph, Weights};
+use portgraph::{Hierarchy, LinkView, NodeIndex, PortGraph, PortView, Weights};
 
 /// Create line graph, connected with two parallel edges at each step.
 ///

--- a/benches/benchmarks/portgraph.rs
+++ b/benches/benchmarks/portgraph.rs
@@ -5,7 +5,7 @@ use super::generators::*;
 use criterion::{
     black_box, criterion_group, AxisScale, BatchSize, BenchmarkId, Criterion, PlotConfiguration,
 };
-use portgraph::PortGraph;
+use portgraph::{PortGraph, PortView};
 
 /// Remove one every five nodes from the graph.
 fn remove_every_five(graph: &mut PortGraph) {

--- a/benches/benchmarks/substitute.rs
+++ b/benches/benchmarks/substitute.rs
@@ -3,7 +3,7 @@
 use criterion::{black_box, criterion_group, BatchSize, Criterion};
 use portgraph::{
     substitute::{BoundedSubgraph, OpenGraph, Rewrite, WeightedRewrite},
-    NodeIndex, PortGraph,
+    LinkView, NodeIndex, PortGraph, PortView,
 };
 
 use super::generators::*;
@@ -11,8 +11,8 @@ use super::generators::*;
 /// Creates a rewrite that replaces a single node with another node.
 fn make_single_node_rewrite(graph: &PortGraph, node: NodeIndex) -> Rewrite {
     // Get the external boundary ports
-    let incoming = graph.input_links(node).flatten().collect::<Vec<_>>();
-    let outgoing = graph.output_links(node).flatten().collect::<Vec<_>>();
+    let incoming = graph.input_links(node).map(|(_, p)| p).collect::<Vec<_>>();
+    let outgoing = graph.output_links(node).map(|(_, p)| p).collect::<Vec<_>>();
 
     // Create a replacement
     let mut g2 = PortGraph::with_capacity(1, incoming.len() + outgoing.len());

--- a/src/algorithms/dominators.rs
+++ b/src/algorithms/dominators.rs
@@ -1,6 +1,6 @@
 use super::postorder_filtered;
 use crate::unmanaged::UnmanagedDenseMap;
-use crate::{Direction, NodeIndex, PortGraph, PortIndex, SecondaryMap};
+use crate::{Direction, LinkView, NodeIndex, PortGraph, PortIndex, PortView, SecondaryMap};
 use std::cmp::Ordering;
 
 /// Returns a dominator tree for a [`PortGraph`], where each node is dominated
@@ -17,7 +17,7 @@ use std::cmp::Ordering;
 ///    ┗> d ┛
 ///
 /// ```
-/// # use portgraph::{algorithms::{dominators, DominatorTree}, Direction, PortGraph};
+/// # use portgraph::{algorithms::{dominators, DominatorTree}, Direction, PortGraph, PortView, LinkView};
 /// let mut graph = PortGraph::with_capacity(5, 10);
 /// let a = graph.add_node(0,2);
 /// let b = graph.add_node(1,1);
@@ -67,7 +67,7 @@ where
 /// a ─┬> b ┐ │    ├─> c ─> e f ─┴> d ┴────────^
 ///
 /// ```
-/// # use portgraph::{algorithms::{dominators_filtered, DominatorTree}, Direction, PortGraph};
+/// # use portgraph::{algorithms::{dominators_filtered, DominatorTree}, Direction, PortGraph, PortView, LinkView};
 /// let mut graph = PortGraph::with_capacity(5, 10);
 /// let a = graph.add_node(0,2);
 /// let b = graph.add_node(1,1);

--- a/src/algorithms/post_order.rs
+++ b/src/algorithms/post_order.rs
@@ -2,7 +2,7 @@ use std::iter::FusedIterator;
 
 use bitvec::vec::BitVec;
 
-use crate::{Direction, NodeIndex, PortGraph, PortIndex};
+use crate::{Direction, LinkView, NodeIndex, PortGraph, PortIndex, PortView};
 
 /// Returns an iterator doing a post-order traversal of a spanning tree in a
 /// [`PortGraph`].
@@ -22,7 +22,7 @@ use crate::{Direction, NodeIndex, PortGraph, PortIndex};
 /// And traverse it in post-order:
 ///
 /// ```
-/// # use portgraph::{algorithms::postorder, Direction, PortGraph};
+/// # use portgraph::{algorithms::postorder, Direction, PortGraph, PortView, LinkView};
 /// let mut graph = PortGraph::new();
 ///
 /// let a = graph.add_node(0, 1);
@@ -78,7 +78,7 @@ pub fn postorder(
 /// And traverse it in post-order:
 ///
 /// ```
-/// # use portgraph::{algorithms::postorder_filtered, Direction, PortGraph};
+/// # use portgraph::{algorithms::postorder_filtered, Direction, PortGraph, PortView, LinkView};
 /// let mut graph = PortGraph::new();
 ///
 /// let a = graph.add_node(0, 1);

--- a/src/algorithms/toposort.rs
+++ b/src/algorithms/toposort.rs
@@ -1,4 +1,4 @@
-use crate::{Direction, NodeIndex, PortGraph, PortIndex, SecondaryMap};
+use crate::{Direction, LinkView, NodeIndex, PortGraph, PortIndex, PortView, SecondaryMap};
 use bitvec::prelude::BitVec;
 use std::{collections::VecDeque, fmt::Debug, iter::FusedIterator};
 
@@ -15,7 +15,7 @@ use std::{collections::VecDeque, fmt::Debug, iter::FusedIterator};
 /// # Example
 ///
 /// ```
-/// # use portgraph::{algorithms::{toposort, TopoSort}, Direction, PortGraph};
+/// # use portgraph::{algorithms::{toposort, TopoSort}, Direction, PortGraph, PortView, LinkView};
 /// let mut graph = PortGraph::new();
 /// let node_a = graph.add_node(2, 2);
 /// let node_b = graph.add_node(2, 2);
@@ -54,7 +54,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use portgraph::{Direction, PortGraph};
+/// # use portgraph::{Direction, PortGraph, PortView, LinkView};
 /// # use portgraph::algorithms::{toposort, toposort_filtered, TopoSort};
 /// let mut graph = PortGraph::new();
 /// let node_a = graph.add_node(2, 2);

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Display;
 
-use crate::{Direction, Hierarchy, NodeIndex, PortGraph, PortIndex, Weights};
+use crate::{Direction, Hierarchy, LinkView, NodeIndex, PortGraph, PortIndex, PortView, Weights};
 
 /// Style of an edge in a dot graph. Defaults to "None".
 pub type DotEdgeStyle = Option<String>;
@@ -196,6 +196,8 @@ fn get_edge_dot(
 
 #[cfg(test)]
 mod tests {
+    use crate::{LinkView, PortView};
+
     use super::*;
 
     #[test]

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -13,7 +13,7 @@
 //! # Example
 //!
 //! ```
-//! # use portgraph::{PortGraph, NodeIndex, PortIndex};
+//! # use portgraph::{PortGraph, NodeIndex, PortIndex, PortView, LinkView};
 //! # use portgraph::hierarchy::Hierarchy;
 //! let mut graph = PortGraph::new();
 //! let mut hierarchy = Hierarchy::new();
@@ -555,7 +555,7 @@ pub enum AttachError {
 
 #[cfg(test)]
 mod test {
-    use crate::PortGraph;
+    use crate::{PortGraph, PortView};
 
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! # Example
 //!
 //! ```
-//! use portgraph::{PortGraph, Direction};
+//! use portgraph::{PortGraph, Direction, PortView, LinkView};
 //! use portgraph::algorithms::{toposort, TopoSort};
 //!
 //! // Create a graph with two nodes, each with two input and two output ports

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ pub mod portgraph;
 pub mod secondary;
 pub mod substitute;
 pub mod unmanaged;
+pub mod view;
 pub mod weights;
 
 #[cfg(feature = "pyo3")]
@@ -86,6 +87,8 @@ pub use crate::portgraph::{LinkError, PortGraph};
 pub use crate::secondary::SecondaryMap;
 #[doc(inline)]
 pub use crate::unmanaged::UnmanagedDenseMap;
+#[doc(inline)]
+pub use crate::view::MultiView;
 #[doc(inline)]
 pub use crate::weights::Weights;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub use crate::secondary::SecondaryMap;
 #[doc(inline)]
 pub use crate::unmanaged::UnmanagedDenseMap;
 #[doc(inline)]
-pub use crate::view::MultiView;
+pub use crate::view::{LinkView, MultiView, PortView};
 #[doc(inline)]
 pub use crate::weights::Weights;
 

--- a/src/multiportgraph.rs
+++ b/src/multiportgraph.rs
@@ -6,6 +6,7 @@ pub use self::iter::{
     Neighbours, NodeConnections, NodeLinks, NodeSubports, Nodes, PortLinks, Ports,
 };
 use crate::portgraph::{NodePortOffsets, NodePorts, PortOperation};
+use crate::view::MultiView;
 use crate::{Direction, LinkError, NodeIndex, PortGraph, PortIndex, PortOffset, SecondaryMap};
 
 use bitvec::vec::BitVec;
@@ -80,46 +81,63 @@ impl MultiPortGraph {
         &self.graph
     }
 
-    /// Adds a node to the portgraph with a given number of input and output ports.
+    /// Given a node in the underlying flat portgraph, returns the main node for it.
     ///
-    /// # Panics
-    ///
-    /// Panics if the total number of ports exceeds `u16::MAX`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use portgraph::multiportgraph::MultiPortGraph;
-    /// # use portgraph::Direction;
-    /// let mut g = MultiPortGraph::new();
-    /// let node = g.add_node(4, 3);
-    /// assert_eq!(g.inputs(node).count(), 4);
-    /// assert_eq!(g.outputs(node).count(), 3);
-    /// assert!(g.contains_node(node));
-    /// ```
-    pub fn add_node(&mut self, incoming: usize, outgoing: usize) -> NodeIndex {
+    /// If the node is not a copy node, returns the node itself.
+    pub fn pg_main_node(&self, node: NodeIndex) -> NodeIndex {
+        if !self.copy_node.get(node) {
+            return node;
+        }
+        self.port_node(self.copy_node_main_port(node).unwrap())
+            .unwrap()
+    }
+}
+
+impl MultiView for MultiPortGraph {
+    type SubportIndex = SubportIndex;
+
+    type Nodes<'a> = Nodes<'a>
+    where
+        Self: 'a;
+
+    type Ports<'a> = Ports<'a>
+    where
+        Self: 'a;
+
+    type NodePorts<'a> = NodePorts
+    where
+        Self: 'a;
+
+    type NodeSubports<'a> = NodeSubports<'a>
+    where
+        Self: 'a;
+
+    type NodePortOffsets<'a> = NodePortOffsets
+    where
+        Self: 'a;
+
+    type NodeConnections<'a> = NodeConnections<'a>
+    where
+        Self: 'a;
+
+    type NodeLinks<'a> = NodeLinks<'a>
+    where
+        Self: 'a;
+
+    type PortLinks<'a> = PortLinks<'a>
+    where
+        Self: 'a;
+
+    type Neighbours<'a> = Neighbours<'a>
+    where
+        Self: 'a;
+
+    #[inline]
+    fn add_node(&mut self, incoming: usize, outgoing: usize) -> NodeIndex {
         self.graph.add_node(incoming, outgoing)
     }
 
-    /// Remove a node from the port graph. All ports of the node will be
-    /// unlinked and removed as well. Does nothing if the node does not exist.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use portgraph::multiportgraph::MultiPortGraph;
-    /// # use portgraph::Direction;
-    /// let mut g = MultiPortGraph::new();
-    /// let node0 = g.add_node(1, 1);
-    /// let node1 = g.add_node(1, 1);
-    /// g.link_ports(g.outputs(node0).nth(0).unwrap(), g.inputs(node1).nth(0).unwrap());
-    /// g.link_ports(g.outputs(node1).nth(0).unwrap(), g.inputs(node0).nth(0).unwrap());
-    /// g.remove_node(node0);
-    /// assert!(!g.contains_node(node0));
-    /// assert!(g.port_link(g.outputs(node1).nth(0).unwrap()).is_none());
-    /// assert!(g.port_link(g.inputs(node1).nth(0).unwrap()).is_none());
-    /// ```
-    pub fn remove_node(&mut self, node: NodeIndex) {
+    fn remove_node(&mut self, node: NodeIndex) {
         debug_assert!(!self.copy_node.get(node));
         for port in self.graph.all_ports(node) {
             if *self.multiport.get(port) {
@@ -129,49 +147,21 @@ impl MultiPortGraph {
         self.graph.remove_node(node);
     }
 
-    /// Link an output port to an input port.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use portgraph::multiportgraph::MultiPortGraph;
-    /// # use portgraph::Direction;
-    /// let mut g = MultiPortGraph::new();
-    /// let node0 = g.add_node(0, 1);
-    /// let node1 = g.add_node(1, 0);
-    /// let node0_output = g.output(node0, 0).unwrap();
-    /// let node1_input = g.input(node1, 0).unwrap();
-    /// g.link_ports(node0_output, node1_input).unwrap();
-    /// assert_eq!(g.port_link(node0_output).unwrap().port(), node1_input);
-    /// assert_eq!(g.port_link(node1_input).unwrap().port(), node0_output);
-    /// ```
-    ///
-    /// # Errors
-    ///
-    ///  - If `port_a` or `port_b` does not exist.
-    ///  - If `port_a` and `port_b` have the same direction.
-    pub fn link_ports(
+    fn link_ports(
         &mut self,
         port_a: PortIndex,
         port_b: PortIndex,
-    ) -> Result<(SubportIndex, SubportIndex), LinkError> {
+    ) -> Result<(Self::SubportIndex, Self::SubportIndex), LinkError> {
         let (multiport_a, index_a) = self.get_free_multiport(port_a)?;
         let (multiport_b, index_b) = self.get_free_multiport(port_b)?;
         self.graph.link_ports(index_a, index_b)?;
         Ok((multiport_a, multiport_b))
     }
 
-    /// Link an output subport to an input subport.
-    ///
-    /// # Errors
-    ///
-    ///  - If `subport_from` or `subport_to` does not exist.
-    ///  - If `subport_a` and `subport_b` have the same direction.
-    ///  - If `subport_from` or `subport_to` is already linked.
-    pub fn link_subports(
+    fn link_subports(
         &mut self,
-        subport_from: SubportIndex,
-        subport_to: SubportIndex,
+        subport_from: Self::SubportIndex,
+        subport_to: Self::SubportIndex,
     ) -> Result<(), LinkError> {
         // TODO: Custom errors
         let from_index = self
@@ -183,8 +173,7 @@ impl MultiPortGraph {
         self.graph.link_ports(from_index, to_index)
     }
 
-    /// Unlinks all connections to the `port`. Return `false` if the port was not linked.
-    pub fn unlink_port(&mut self, port: PortIndex) -> bool {
+    fn unlink_port(&mut self, port: PortIndex) -> bool {
         if self.is_multiport(port) {
             let link = self
                 .graph
@@ -197,401 +186,162 @@ impl MultiPortGraph {
         }
     }
 
-    /// Unlinks the `port` and returns the port it was linked to. Returns `None`
-    /// when the port was not linked.
-    ///
-    /// TODO: Remove copy nodes when they are no longer needed?
-    pub fn unlink_subport(&mut self, subport: SubportIndex) -> Option<SubportIndex> {
+    fn unlink_subport(&mut self, subport: Self::SubportIndex) -> Option<Self::SubportIndex> {
+        // TODO: Remove copy nodes when they are no longer needed?
         let subport_index = self.get_subport_index(subport)?;
         let link = self.graph.unlink_port(subport_index)?;
         self.get_subport_from_index(link)
     }
 
-    /// Returns an iterator over every pair of matching ports connecting `from`
-    /// with `to`.
-    ///
-    /// # Example
-    /// ```
-    /// # use portgraph::multiportgraph::{MultiPortGraph, SubportIndex};
-    /// # use portgraph::{NodeIndex, PortIndex, Direction};
-    /// # use itertools::Itertools;
-    /// let mut g = MultiPortGraph::new();
-    /// let a = g.add_node(0, 2);
-    /// let b = g.add_node(2, 0);
-    ///
-    /// g.link_nodes(a, 0, b, 0).unwrap();
-    /// g.link_nodes(a, 0, b, 1).unwrap();
-    /// g.link_nodes(a, 1, b, 1).unwrap();
-    ///
-    /// let mut connections = g.get_connections(a, b);
-    /// let (out0, out1) = g.outputs(a).collect_tuple().unwrap();
-    /// let (in0, in1) = g.inputs(b).collect_tuple().unwrap();
-    /// assert_eq!(connections.next().unwrap(), (SubportIndex::new_multi(out0,0), SubportIndex::new_multi(in0,0)));
-    /// assert_eq!(connections.next().unwrap(), (SubportIndex::new_multi(out0,1), SubportIndex::new_multi(in1,0)));
-    /// assert_eq!(connections.next().unwrap(), (SubportIndex::new_multi(out1,0), SubportIndex::new_multi(in1,1)));
-    /// assert_eq!(connections.next(), None);
-    /// ```
-    #[must_use]
     #[inline]
-    pub fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> NodeConnections<'_> {
+    fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> Self::NodeConnections<'_> {
         NodeConnections::new(self, to, self.output_links(from))
     }
 
-    /// Checks whether there is a directed link between the two nodes and
-    /// returns the first matching pair of ports.
-    ///
-    /// # Example
-    /// ```
-    /// # use portgraph::multiportgraph::{MultiPortGraph, SubportIndex};
-    /// # use portgraph::{NodeIndex, PortIndex, Direction};
-    /// let mut g = MultiPortGraph::new();
-    /// let a = g.add_node(0, 2);
-    /// let b = g.add_node(2, 0);
-    ///
-    /// g.link_nodes(a, 0, b, 0).unwrap();
-    /// g.link_nodes(a, 1, b, 1).unwrap();
-    ///
-    /// let out0 = g.output(a, 0).unwrap();
-    /// let in0 = g.input(b, 0).unwrap();
-    /// assert_eq!(g.get_connection(a, b), Some((SubportIndex::new_multi(out0,0), SubportIndex::new_multi(in0,0))));
-    /// ```
-    #[must_use]
     #[inline]
-    pub fn get_connection(
-        &self,
-        from: NodeIndex,
-        to: NodeIndex,
-    ) -> Option<(SubportIndex, SubportIndex)> {
-        self.get_connections(from, to).next()
-    }
-
-    /// Checks whether there is a directed link between the two nodes.
-    ///
-    /// # Example
-    /// ```
-    /// # use portgraph::multiportgraph::MultiPortGraph;
-    /// # use portgraph::{NodeIndex, PortIndex, Direction};
-    /// let mut g = MultiPortGraph::new();
-    /// let a = g.add_node(0, 2);
-    /// let b = g.add_node(2, 0);
-    ///
-    /// g.link_nodes(a, 0, b, 0).unwrap();
-    ///
-    /// assert!(g.connected(a, b));
-    /// ```
-    #[must_use]
-    #[inline]
-    pub fn connected(&self, from: NodeIndex, to: NodeIndex) -> bool {
-        self.get_connection(from, to).is_some()
-    }
-
-    /// Links two nodes at an input and output port offsets.
-    pub fn link_nodes(
-        &mut self,
-        from: NodeIndex,
-        from_output: usize,
-        to: NodeIndex,
-        to_input: usize,
-    ) -> Result<(SubportIndex, SubportIndex), LinkError> {
-        self.link_offsets(
-            from,
-            PortOffset::new_outgoing(from_output),
-            to,
-            PortOffset::new_incoming(to_input),
-        )
-    }
-
-    /// Links two nodes at an input and output port offsets.
-    ///
-    /// # Errors
-    ///
-    ///  - If the ports and nodes do not exist.
-    ///  - If the ports have the same direction.
-    pub fn link_offsets(
-        &mut self,
-        node_a: NodeIndex,
-        offset_a: PortOffset,
-        node_b: NodeIndex,
-        offset_b: PortOffset,
-    ) -> Result<(SubportIndex, SubportIndex), LinkError> {
-        let from_port = self
-            .port_index(node_a, offset_a)
-            .ok_or(LinkError::UnknownOffset {
-                node: node_a,
-                offset: offset_a,
-            })?;
-        let to_port = self
-            .port_index(node_b, offset_b)
-            .ok_or(LinkError::UnknownOffset {
-                node: node_b,
-                offset: offset_b,
-            })?;
-        self.link_ports(from_port, to_port)
-    }
-
-    /// Returns the direction of the `port`.
-    #[inline]
-    pub fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction> {
+    fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction> {
         self.graph.port_direction(port.into())
     }
 
-    /// Returns the node that the `port` belongs to.
     #[inline]
-    pub fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex> {
+    fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex> {
         self.graph.port_node(port.into())
     }
 
-    /// Returns the index of a `port` within its node's port list.
-    pub fn port_offset(&self, port: impl Into<PortIndex>) -> Option<PortOffset> {
+    #[inline]
+    fn port_offset(&self, port: impl Into<PortIndex>) -> Option<PortOffset> {
         self.graph.port_offset(port.into())
     }
 
-    /// Returns the port index for a given node, direction, and offset.
-    #[must_use]
-    pub fn port_index(&self, node: NodeIndex, offset: PortOffset) -> Option<PortIndex> {
+    #[inline]
+    fn port_index(&self, node: NodeIndex, offset: PortOffset) -> Option<PortIndex> {
         self.graph.port_index(node, offset)
     }
 
-    /// Returns the port that the given `port` is linked to.
     #[inline]
-    pub fn port_links(&self, port: PortIndex) -> PortLinks {
+    fn port_links(&self, port: PortIndex) -> Self::PortLinks<'_> {
         PortLinks::new(self, port)
     }
 
-    /// Return the link to the provided port, if not connected return None.
-    /// If this port has multiple connected subports, an arbitrary one is returned.
-    #[inline]
-    pub fn port_link(&self, port: PortIndex) -> Option<SubportIndex> {
-        self.port_links(port).next().map(|(_, p)| p)
-    }
-
-    /// Return the subport linked to the given `port`. If the port is not
-    /// connected, return None.
-    pub fn subport_link(&self, subport: SubportIndex) -> Option<SubportIndex> {
+    fn subport_link(&self, subport: Self::SubportIndex) -> Option<Self::SubportIndex> {
         let subport_index = self.get_subport_index(subport)?;
         let link = self.graph.port_link(subport_index)?;
         self.get_subport_from_index(link)
     }
 
-    /// Iterates over all the ports of the `node` in the given `direction`.
-    pub fn ports(&self, node: NodeIndex, direction: Direction) -> NodePorts {
+    #[inline]
+    fn ports(&self, node: NodeIndex, direction: Direction) -> Self::NodePorts<'_> {
         self.graph.ports(node, direction)
     }
 
-    /// Iterates over the input and output ports of the `node` in sequence.
-    pub fn all_ports(&self, node: NodeIndex) -> NodePorts {
+    #[inline]
+    fn all_ports(&self, node: NodeIndex) -> Self::NodePorts<'_> {
         self.graph.all_ports(node)
     }
 
-    /// Returns the input port at the given offset in the `node`.
-    ///
-    /// Shorthand for [`MultiPortGraph::port_index`].
     #[inline]
-    pub fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex> {
+    fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex> {
         self.graph.input(node, offset)
     }
 
-    /// Returns the output port at the given offset in the `node`.
-    ///
-    /// Shorthand for [`MultiPortGraph::ports`].
     #[inline]
-    pub fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex> {
+    fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex> {
         self.graph.output(node, offset)
     }
 
-    /// Iterates over all the input ports of the `node`.
-    ///
-    /// Shorthand for [`MultiPortGraph::ports`].
     #[inline]
-    pub fn inputs(&self, node: NodeIndex) -> NodePorts {
+    fn inputs(&self, node: NodeIndex) -> Self::NodePorts<'_> {
         self.graph.inputs(node)
     }
 
-    /// Iterates over all the output ports of the `node`.
-    ///
-    /// Shorthand for [`MultiPortGraph::ports`].
     #[inline]
-    pub fn outputs(&self, node: NodeIndex) -> NodePorts {
+    fn outputs(&self, node: NodeIndex) -> Self::NodePorts<'_> {
         self.graph.outputs(node)
     }
 
-    /// Returns the number of input ports of the `node`.
-    ///
-    /// Shorthand for [`MultiPortGraph::num_ports`].
     #[inline]
-    pub fn num_inputs(&self, node: NodeIndex) -> usize {
-        self.graph.num_inputs(node)
-    }
-
-    /// Returns the number of output ports of the `node`.
-    ///
-    /// Shorthand for [`MultiPortGraph::num_ports`].
-    #[inline]
-    pub fn num_outputs(&self, node: NodeIndex) -> usize {
-        self.graph.num_outputs(node)
-    }
-
-    /// Returns the number of ports of the `node` in the given `direction`.
-    #[inline]
-    pub fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize {
+    fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize {
         self.graph.num_ports(node, direction)
     }
 
-    /// Iterates over all the ports of the `node` in the given `direction`.
-    pub fn subports(&self, node: NodeIndex, direction: Direction) -> NodeSubports {
+    #[inline]
+    fn subports(&self, node: NodeIndex, direction: Direction) -> Self::NodeSubports<'_> {
         NodeSubports::new(self, self.graph.ports(node, direction))
     }
 
-    /// Iterates over the input and output ports of the `node` in sequence.
-    pub fn all_subports(&self, node: NodeIndex) -> NodeSubports {
+    #[inline]
+    fn all_subports(&self, node: NodeIndex) -> Self::NodeSubports<'_> {
         NodeSubports::new(self, self.graph.all_ports(node))
     }
 
-    /// Iterates over all the input ports of the `node`.
-    ///
-    /// Shorthand for [`MultiPortGraph::subports`].
     #[inline]
-    pub fn subport_inputs(&self, node: NodeIndex) -> NodeSubports {
-        self.subports(node, Direction::Incoming)
-    }
-
-    /// Iterates over all the output ports of the `node`.
-    ///
-    /// Shorthand for [`MultiPortGraph::subports`].
-    #[inline]
-    pub fn subport_outputs(&self, node: NodeIndex) -> NodeSubports {
-        self.subports(node, Direction::Outgoing)
-    }
-
-    /// Iterates over all the port offsets of the `node` in the given `direction`.
-    pub fn port_offsets(&self, node: NodeIndex, direction: Direction) -> NodePortOffsets {
+    fn port_offsets(&self, node: NodeIndex, direction: Direction) -> Self::NodePortOffsets<'_> {
         self.graph.port_offsets(node, direction)
     }
 
-    /// Iterates over all the input port offsets of the `node`.
-    ///
-    /// Shorthand for [`MultiPortGraph::port_offsets`].
     #[inline]
-    pub fn input_offsets(&self, node: NodeIndex) -> NodePortOffsets {
-        self.graph.input_offsets(node)
-    }
-
-    /// Iterates over all the output port offsets of the `node`.
-    ///
-    /// Shorthand for [`MultiPortGraph::port_offsets`].
-    #[inline]
-    pub fn output_offsets(&self, node: NodeIndex) -> NodePortOffsets {
-        self.graph.output_offsets(node)
-    }
-
-    /// Iterates over the input and output port offsets of the `node` in sequence.
-    #[inline]
-    pub fn all_port_offsets(&self, node: NodeIndex) -> NodePortOffsets {
+    fn all_port_offsets(&self, node: NodeIndex) -> Self::NodePortOffsets<'_> {
         self.graph.all_port_offsets(node)
     }
 
-    /// Iterates over the connected links of the `node` in the given
-    /// `direction`.
-    ///
-    /// In contrast to [`PortGraph::links`], this iterator only returns linked
-    /// subports, and includes the source subport.
-    ///
-    /// [`PortGraph::links`]: crate::portgraph::PortGraph::links
     #[inline]
-    pub fn links(&self, node: NodeIndex, direction: Direction) -> NodeLinks<'_> {
+    fn links(&self, node: NodeIndex, direction: Direction) -> Self::NodeLinks<'_> {
         NodeLinks::new(self, self.ports(node, direction))
     }
 
-    /// Iterates over the connected input links of the `node`. Shorthand for
-    /// [`MultiPortGraph::links`].
     #[inline]
-    pub fn input_links(&self, node: NodeIndex) -> NodeLinks<'_> {
-        self.links(node, Direction::Incoming)
-    }
-
-    /// Iterates over the connected output links of the `node`. Shorthand for
-    /// [`MultiPortGraph::links`].
-    #[inline]
-    pub fn output_links(&self, node: NodeIndex) -> NodeLinks<'_> {
-        self.links(node, Direction::Outgoing)
-    }
-
-    /// Iterates over the connected input and output links of the `node` in sequence.
-    #[inline]
-    pub fn all_links(&self, node: NodeIndex) -> NodeLinks<'_> {
+    fn all_links(&self, node: NodeIndex) -> Self::NodeLinks<'_> {
         NodeLinks::new(self, self.all_ports(node))
     }
 
-    /// Iterates over neighbour nodes in the given `direction`.
-    /// May contain duplicates if the graph has multiple links between nodes.
     #[inline]
-    pub fn neighbours(&self, node: NodeIndex, direction: Direction) -> Neighbours<'_> {
+    fn neighbours(&self, node: NodeIndex, direction: Direction) -> Self::Neighbours<'_> {
         Neighbours::new(self, self.subports(node, direction))
     }
 
-    /// Iterates over the input neighbours of the `node`. Shorthand for [`MultiPortGraph::neighbours`].
     #[inline]
-    pub fn input_neighbours(&self, node: NodeIndex) -> Neighbours<'_> {
-        self.neighbours(node, Direction::Incoming)
-    }
-
-    /// Iterates over the output neighbours of the `node`. Shorthand for [`MultiPortGraph::neighbours`].
-    #[inline]
-    pub fn output_neighbours(&self, node: NodeIndex) -> Neighbours<'_> {
-        self.neighbours(node, Direction::Outgoing)
-    }
-
-    /// Iterates over the input and output neighbours of the `node` in sequence.
-    #[inline]
-    pub fn all_neighbours(&self, node: NodeIndex) -> Neighbours<'_> {
+    fn all_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_> {
         Neighbours::new(self, self.all_subports(node))
     }
 
-    /// Returns whether the port graph contains the `node`.
     #[inline]
-    pub fn contains_node(&self, node: NodeIndex) -> bool {
+    fn contains_node(&self, node: NodeIndex) -> bool {
         self.graph.contains_node(node) && !self.copy_node.get(node)
     }
 
-    /// Returns whether the port graph contains the `port`.
     #[inline]
-    pub fn contains_port(&self, port: PortIndex) -> bool {
+    fn contains_port(&self, port: PortIndex) -> bool {
         self.graph
             .port_node(port)
             .map_or(false, |node| !self.copy_node.get(node))
     }
 
-    /// Returns whether the port graph has no nodes nor ports.
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.node_count() == 0
     }
 
-    /// Returns the number of nodes in the port graph.
     #[inline]
-    pub fn node_count(&self) -> usize {
+    fn node_count(&self) -> usize {
         self.graph.node_count() - self.copy_node_count
     }
 
-    /// Returns the number of ports in the port graph.
     #[inline]
-    pub fn port_count(&self) -> usize {
+    fn port_count(&self) -> usize {
         // Do not count the ports in the copy nodes. We have to subtract one of
         // the two ports connecting the copy nodes with their main nodes, in
         // addition to all the subports.
         self.graph.port_count() - self.subport_count - self.copy_node_count
     }
 
-    /// Returns the number of links between ports.
     #[inline]
-    pub fn link_count(&self) -> usize {
+    fn link_count(&self) -> usize {
         // Do not count the links between copy nodes and their main nodes.
         self.graph.link_count() - self.copy_node_count
     }
 
-    /// Iterates over the nodes in the port graph.
     #[inline]
-    pub fn nodes_iter(&self) -> Nodes<'_> {
+    fn nodes_iter(&self) -> Self::Nodes<'_> {
         self::iter::Nodes {
             multigraph: self,
             iter: self.graph.nodes_iter(),
@@ -599,14 +349,12 @@ impl MultiPortGraph {
         }
     }
 
-    /// Iterates over the ports in the port graph.
     #[inline]
-    pub fn ports_iter(&self) -> Ports<'_> {
+    fn ports_iter(&self) -> Self::Ports<'_> {
         Ports::new(self, self.graph.ports_iter())
     }
 
-    /// Removes all nodes and ports from the port graph.
-    pub fn clear(&mut self) {
+    fn clear(&mut self) {
         self.graph.clear();
         self.multiport.clear();
         self.copy_node.clear();
@@ -614,54 +362,31 @@ impl MultiPortGraph {
         self.subport_count = 0;
     }
 
-    /// Returns the capacity of the underlying buffer for nodes.
     #[inline]
-    pub fn node_capacity(&self) -> usize {
+    fn node_capacity(&self) -> usize {
         self.graph.node_capacity() - self.copy_node_count
     }
 
-    /// Returns the capacity of the underlying buffer for ports.
     #[inline]
-    pub fn port_capacity(&self) -> usize {
+    fn port_capacity(&self) -> usize {
         // See [`MultiPortGraph::port_count`]
         self.graph.port_capacity() - self.subport_count - self.copy_node_count
     }
 
-    /// Returns the allocated port capacity for a specific node.
-    ///
-    /// Changes to the number of ports of the node will not reallocate
-    /// until the number of ports exceeds this capacity.
     #[inline]
-    pub fn node_port_capacity(&self, node: NodeIndex) -> usize {
+    fn node_port_capacity(&self, node: NodeIndex) -> usize {
         self.graph.node_port_capacity(node)
     }
 
-    /// Reserves enough capacity to insert at least the given number of additional nodes and ports.
-    ///
-    /// This method does not take into account the length of the free list and might overallocate speculatively.
-    pub fn reserve(&mut self, nodes: usize, ports: usize) {
+    #[inline]
+    fn reserve(&mut self, nodes: usize, ports: usize) {
         self.graph.reserve(nodes, ports);
         self.multiport.reserve(ports);
         self.copy_node.reserve(nodes);
     }
 
-    /// Changes the number of ports of the `node` to the given `incoming` and `outgoing` counts.
-    ///
-    /// Invalidates the indices of the node's ports. If the number of incoming or outgoing ports
-    /// is reduced, the ports are removed from the end of the port list.
-    ///
-    /// Every time a port is moved, the `rekey` function will be called with its old and new index.
-    /// If the port is removed, the new index will be `None`.
-    ///
-    /// This operation is O(n) where n is the number of ports of the node.
-    #[allow(unreachable_code)] // TODO
-    pub fn set_num_ports<F>(
-        &mut self,
-        node: NodeIndex,
-        incoming: usize,
-        outgoing: usize,
-        mut rekey: F,
-    ) where
+    fn set_num_ports<F>(&mut self, node: NodeIndex, incoming: usize, outgoing: usize, mut rekey: F)
+    where
         F: FnMut(PortIndex, PortOperation),
     {
         let mut dropped_ports = Vec::new();
@@ -682,13 +407,7 @@ impl MultiPortGraph {
         }
     }
 
-    /// Compacts the storage of nodes in the portgraph. Note that indices won't
-    /// necessarily be consecutively after this process, as there may be
-    /// hidden copy nodes.
-    ///
-    /// Every time a node is moved, the `rekey` function will be called with its
-    /// old and new index.
-    pub fn compact_nodes<F>(&mut self, mut rekey: F)
+    fn compact_nodes<F>(&mut self, mut rekey: F)
     where
         F: FnMut(NodeIndex, NodeIndex),
     {
@@ -698,13 +417,7 @@ impl MultiPortGraph {
         });
     }
 
-    /// Compacts the storage of ports in the portgraph. Note that indices won't
-    /// necessarily be consecutively after this process, as there may be hidden
-    /// copy nodes.
-    ///
-    /// Every time a port is moved, the `rekey` function will be called with is
-    /// old and new index.
-    pub fn compact_ports<F>(&mut self, mut rekey: F)
+    fn compact_ports<F>(&mut self, mut rekey: F)
     where
         F: FnMut(PortIndex, PortIndex),
     {
@@ -714,24 +427,10 @@ impl MultiPortGraph {
         });
     }
 
-    /// Shrinks the underlying buffers to the fit the data.
-    ///
-    /// This does not move nodes or ports, which might prevent freeing up more capacity.
-    pub fn shrink_to_fit(&mut self) {
+    fn shrink_to_fit(&mut self) {
         self.graph.shrink_to_fit();
         self.multiport.shrink_to_fit();
         self.copy_node.shrink_to_fit();
-    }
-
-    /// Given a node in the underlying flat portgraph, returns the main node for it.
-    ///
-    /// If the node is not a copy node, returns the node itself.
-    pub fn pg_main_node(&self, node: NodeIndex) -> NodeIndex {
-        if !self.copy_node.get(node) {
-            return node;
-        }
-        self.port_node(self.copy_node_main_port(node).unwrap())
-            .unwrap()
     }
 }
 

--- a/src/multiportgraph/iter.rs
+++ b/src/multiportgraph/iter.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 
 use super::{MultiPortGraph, SubportIndex};
 use crate::portgraph::{self, NodePorts};
-use crate::{NodeIndex, PortIndex, PortOffset, PortView};
+use crate::{LinkView, NodeIndex, PortIndex, PortOffset, PortView};
 
 /// Iterator over the nodes of a graph.
 #[derive(Clone)]

--- a/src/multiportgraph/iter.rs
+++ b/src/multiportgraph/iter.rs
@@ -5,6 +5,7 @@ use std::ops::Range;
 
 use super::{MultiPortGraph, SubportIndex};
 use crate::portgraph::{self, NodePorts};
+use crate::view::MultiView;
 use crate::{NodeIndex, PortIndex, PortOffset};
 
 /// Iterator over the nodes of a graph.

--- a/src/multiportgraph/iter.rs
+++ b/src/multiportgraph/iter.rs
@@ -5,8 +5,7 @@ use std::ops::Range;
 
 use super::{MultiPortGraph, SubportIndex};
 use crate::portgraph::{self, NodePorts};
-use crate::view::MultiView;
-use crate::{NodeIndex, PortIndex, PortOffset};
+use crate::{NodeIndex, PortIndex, PortOffset, PortView};
 
 /// Iterator over the nodes of a graph.
 #[derive(Clone)]

--- a/src/proptest.rs
+++ b/src/proptest.rs
@@ -4,7 +4,7 @@
 //! returns strategies that generate random portgraphs.
 use std::iter::zip;
 
-use crate::{Direction, NodeIndex, PortGraph, PortIndex};
+use crate::{Direction, LinkView, NodeIndex, PortGraph, PortIndex, PortView};
 use proptest::prelude::*;
 use rand::seq::SliceRandom;
 
@@ -99,8 +99,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::gen_portgraph;
-    use proptest::prelude::*;
+    use super::*;
 
     proptest! {
         #[test]

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -56,10 +56,10 @@ pub trait SecondaryMap<K, V> {
     /// Remove key `old` and optionally move to key `new`.
     ///
     /// This method is useful for rekey callbacks such as in
-    /// [`PortGraph::set_num_ports`] and [`PortGraph::compact_nodes`].
+    /// [`PortView::set_num_ports`] and [`PortView::compact_nodes`].
     ///
-    /// [`PortGraph::set_num_ports`]: crate::portgraph::PortGraph::set_num_ports
-    /// [`PortGraph::compact_nodes`]: crate::portgraph::PortGraph::compact_nodes
+    /// [`PortView::set_num_ports`]: crate::PortView::set_num_ports
+    /// [`PortView::compact_nodes`]: crate::PortView::compact_nodes
     #[inline]
     fn rekey(&mut self, old: K, new: Option<K>) {
         let val = self.take(old);

--- a/src/substitute.rs
+++ b/src/substitute.rs
@@ -8,7 +8,7 @@
 
 use crate::portgraph::LinkError;
 use crate::weights::Weights;
-use crate::{NodeIndex, PortGraph, PortIndex};
+use crate::{LinkView, NodeIndex, PortGraph, PortIndex, PortView};
 
 use bitvec::bitvec;
 use bitvec::prelude::BitVec;
@@ -157,8 +157,8 @@ impl BoundedSubgraph {
     pub fn from_node(graph: &PortGraph, node: NodeIndex) -> Self {
         Self {
             subgraph: [node].into_iter().collect(),
-            inputs: graph.input_links(node).flatten().collect(),
-            outputs: graph.output_links(node).flatten().collect(),
+            inputs: graph.input_links(node).map(|(_, p)| p).collect(),
+            outputs: graph.output_links(node).map(|(_, p)| p).collect(),
         }
     }
 
@@ -389,7 +389,7 @@ mod tests {
     use std::error::Error;
 
     use crate::substitute::{BoundedSubgraph, OpenGraph, Rewrite, WeightedRewrite};
-    use crate::{PortGraph, Weights};
+    use crate::{LinkView, PortGraph, PortView, Weights};
 
     #[test]
     fn test_remove_subgraph() -> Result<(), Box<dyn Error>> {

--- a/src/unmanaged.rs
+++ b/src/unmanaged.rs
@@ -15,7 +15,7 @@
 //! # Example
 //!
 //! ```
-//! # use portgraph::{PortGraph, NodeIndex, PortIndex};
+//! # use portgraph::{PortGraph, NodeIndex, PortIndex, PortView, LinkView};
 //! # use portgraph::unmanaged::UnmanagedDenseMap;
 //!
 //! let mut graph = PortGraph::new();
@@ -156,10 +156,10 @@ where
     /// Remove key `old` and optionally move to key `new`.
     ///
     /// This method is useful for rekey callbacks such as in
-    /// [`PortGraph::set_num_ports`] and [`PortGraph::compact_nodes`].
+    /// [`PortView::set_num_ports`] and [`PortView::compact_nodes`].
     ///
-    /// [`PortGraph::set_num_ports`]: crate::portgraph::PortGraph::set_num_ports
-    /// [`PortGraph::compact_nodes`]: crate::portgraph::PortGraph::compact_nodes
+    /// [`PortView::set_num_ports`]: crate::PortView::set_num_ports
+    /// [`PortView::compact_nodes`]: crate::PortView::compact_nodes
     pub fn rekey(&mut self, old: K, new: Option<K>)
     where
         V: Default,

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,0 +1,547 @@
+//! Abstractions over portgraph representations.
+
+use crate::{portgraph::PortOperation, Direction, LinkError, NodeIndex, PortIndex, PortOffset};
+
+/// Abstraction over a portgraph that may have multiple connections per node.
+pub trait MultiView {
+    /// An index type used to identify specific connections in a multiport.
+    type SubportIndex;
+
+    /// Iterator over the nodes of the graph.
+    type Nodes<'a>: Iterator<Item = NodeIndex>
+    where
+        Self: 'a;
+
+    /// Iterator over the ports of the graph.
+    type Ports<'a>: Iterator<Item = PortIndex>
+    where
+        Self: 'a;
+
+    /// Iterator over the ports of a node.
+    type NodePorts<'a>: Iterator<Item = PortIndex>
+    where
+        Self: 'a;
+
+    /// Iterator over the sub ports of each port in a node.
+    type NodeSubports<'a>: Iterator<Item = Self::SubportIndex>
+    where
+        Self: 'a;
+
+    /// Iterator over the sub ports of each port in a node.
+    type NodePortOffsets<'a>: Iterator<Item = PortOffset>
+    where
+        Self: 'a;
+
+    /// Iterator over the connections between two nodes.
+    type NodeConnections<'a>: Iterator<Item = (Self::SubportIndex, Self::SubportIndex)>
+    where
+        Self: 'a;
+
+    /// Iterator over the links of a node. Returns pairs of source subport in
+    /// the given node and target subport in the linked node.
+    type NodeLinks<'a>: Iterator<Item = (Self::SubportIndex, Self::SubportIndex)>
+    where
+        Self: 'a;
+
+    /// Iterator over the links of a port. Returns pairs of source subport in
+    /// the given ports and target subport in the linked port.
+    type PortLinks<'a>: Iterator<Item = (Self::SubportIndex, Self::SubportIndex)>
+    where
+        Self: 'a;
+
+    /// Iterator over the neighbours of a node.
+    type Neighbours<'a>: Iterator<Item = NodeIndex>
+    where
+        Self: 'a;
+
+    /// Adds a node to the portgraph with a given number of input and output ports.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the total number of ports exceeds `u16::MAX`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use portgraph::multiportgraph::MultiPortGraph;
+    /// # use portgraph::{Direction, MultiView};
+    /// let mut g = MultiPortGraph::new();
+    /// let node = g.add_node(4, 3);
+    /// assert_eq!(g.inputs(node).count(), 4);
+    /// assert_eq!(g.outputs(node).count(), 3);
+    /// assert!(g.contains_node(node));
+    /// ```
+    fn add_node(&mut self, incoming: usize, outgoing: usize) -> NodeIndex;
+
+    /// Remove a node from the port graph. All ports of the node will be
+    /// unlinked and removed as well. Does nothing if the node does not exist.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use portgraph::multiportgraph::MultiPortGraph;
+    /// # use portgraph::{Direction, MultiView};
+    /// let mut g = MultiPortGraph::new();
+    /// let node0 = g.add_node(1, 1);
+    /// let node1 = g.add_node(1, 1);
+    /// g.link_ports(g.outputs(node0).nth(0).unwrap(), g.inputs(node1).nth(0).unwrap());
+    /// g.link_ports(g.outputs(node1).nth(0).unwrap(), g.inputs(node0).nth(0).unwrap());
+    /// g.remove_node(node0);
+    /// assert!(!g.contains_node(node0));
+    /// assert!(g.port_link(g.outputs(node1).nth(0).unwrap()).is_none());
+    /// assert!(g.port_link(g.inputs(node1).nth(0).unwrap()).is_none());
+    /// ```
+    fn remove_node(&mut self, node: NodeIndex);
+
+    /// Link an output port to an input port.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use portgraph::multiportgraph::MultiPortGraph;
+    /// # use portgraph::{Direction, MultiView};
+    /// let mut g = MultiPortGraph::new();
+    /// let node0 = g.add_node(0, 1);
+    /// let node1 = g.add_node(1, 0);
+    /// let node0_output = g.output(node0, 0).unwrap();
+    /// let node1_input = g.input(node1, 0).unwrap();
+    /// g.link_ports(node0_output, node1_input).unwrap();
+    /// assert_eq!(g.port_link(node0_output).unwrap().port(), node1_input);
+    /// assert_eq!(g.port_link(node1_input).unwrap().port(), node0_output);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    ///  - If `port_a` or `port_b` does not exist.
+    ///  - If `port_a` and `port_b` have the same direction.
+    fn link_ports(
+        &mut self,
+        port_a: PortIndex,
+        port_b: PortIndex,
+    ) -> Result<(Self::SubportIndex, Self::SubportIndex), LinkError>;
+
+    /// Link an output subport to an input subport.
+    ///
+    /// # Errors
+    ///
+    ///  - If `subport_from` or `subport_to` does not exist.
+    ///  - If `subport_a` and `subport_b` have the same direction.
+    ///  - If `subport_from` or `subport_to` is already linked.
+    fn link_subports(
+        &mut self,
+        subport_from: Self::SubportIndex,
+        subport_to: Self::SubportIndex,
+    ) -> Result<(), LinkError>;
+
+    /// Links two nodes at an input and output port offsets.
+    ///
+    /// # Errors
+    ///
+    ///  - If the ports and nodes do not exist.
+    fn link_nodes(
+        &mut self,
+        from: NodeIndex,
+        from_output: usize,
+        to: NodeIndex,
+        to_input: usize,
+    ) -> Result<(Self::SubportIndex, Self::SubportIndex), LinkError> {
+        self.link_offsets(
+            from,
+            PortOffset::new_outgoing(from_output),
+            to,
+            PortOffset::new_incoming(to_input),
+        )
+    }
+
+    /// Links two nodes at an input and output port offsets.
+    ///
+    /// # Errors
+    ///
+    ///  - If the ports and nodes do not exist.
+    ///  - If the ports have the same direction.
+    fn link_offsets(
+        &mut self,
+        node_a: NodeIndex,
+        offset_a: PortOffset,
+        node_b: NodeIndex,
+        offset_b: PortOffset,
+    ) -> Result<(Self::SubportIndex, Self::SubportIndex), LinkError> {
+        let from_port = self
+            .port_index(node_a, offset_a)
+            .ok_or(LinkError::UnknownOffset {
+                node: node_a,
+                offset: offset_a,
+            })?;
+        let to_port = self
+            .port_index(node_b, offset_b)
+            .ok_or(LinkError::UnknownOffset {
+                node: node_b,
+                offset: offset_b,
+            })?;
+        self.link_ports(from_port, to_port)
+    }
+
+    /// Unlinks all connections to the `port`. Return `false` if the port was not linked.
+    fn unlink_port(&mut self, port: PortIndex) -> bool;
+
+    /// Unlinks the `port` and returns the port it was linked to. Returns `None`
+    /// when the port was not linked.
+    fn unlink_subport(&mut self, subport: Self::SubportIndex) -> Option<Self::SubportIndex>;
+
+    /// Returns an iterator over every pair of matching ports connecting `from`
+    /// with `to`.
+    ///
+    /// # Example
+    /// ```
+    /// # use portgraph::multiportgraph::{MultiPortGraph, SubportIndex};
+    /// # use portgraph::{NodeIndex, PortIndex, Direction, MultiView};
+    /// # use itertools::Itertools;
+    /// let mut g = MultiPortGraph::new();
+    /// let a = g.add_node(0, 2);
+    /// let b = g.add_node(2, 0);
+    ///
+    /// g.link_nodes(a, 0, b, 0).unwrap();
+    /// g.link_nodes(a, 0, b, 1).unwrap();
+    /// g.link_nodes(a, 1, b, 1).unwrap();
+    ///
+    /// let mut connections = g.get_connections(a, b);
+    /// let (out0, out1) = g.outputs(a).collect_tuple().unwrap();
+    /// let (in0, in1) = g.inputs(b).collect_tuple().unwrap();
+    /// assert_eq!(connections.next().unwrap(), (SubportIndex::new_multi(out0,0), SubportIndex::new_multi(in0,0)));
+    /// assert_eq!(connections.next().unwrap(), (SubportIndex::new_multi(out0,1), SubportIndex::new_multi(in1,0)));
+    /// assert_eq!(connections.next().unwrap(), (SubportIndex::new_multi(out1,0), SubportIndex::new_multi(in1,1)));
+    /// assert_eq!(connections.next(), None);
+    /// ```
+    #[must_use]
+    fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> Self::NodeConnections<'_>;
+
+    /// Checks whether there is a directed link between the two nodes and
+    /// returns the first matching pair of ports.
+    ///
+    /// # Example
+    /// ```
+    /// # use portgraph::multiportgraph::{MultiPortGraph, SubportIndex};
+    /// # use portgraph::{NodeIndex, PortIndex, Direction, MultiView};
+    /// let mut g = MultiPortGraph::new();
+    /// let a = g.add_node(0, 2);
+    /// let b = g.add_node(2, 0);
+    ///
+    /// g.link_nodes(a, 0, b, 0).unwrap();
+    /// g.link_nodes(a, 1, b, 1).unwrap();
+    ///
+    /// let out0 = g.output(a, 0).unwrap();
+    /// let in0 = g.input(b, 0).unwrap();
+    /// assert_eq!(g.get_connection(a, b), Some((SubportIndex::new_multi(out0,0), SubportIndex::new_multi(in0,0))));
+    /// ```
+    #[must_use]
+    fn get_connection(
+        &self,
+        from: NodeIndex,
+        to: NodeIndex,
+    ) -> Option<(Self::SubportIndex, Self::SubportIndex)> {
+        self.get_connections(from, to).next()
+    }
+
+    /// Checks whether there is a directed link between the two nodes.
+    ///
+    /// # Example
+    /// ```
+    /// # use portgraph::multiportgraph::MultiPortGraph;
+    /// # use portgraph::{NodeIndex, PortIndex, Direction, MultiView};
+    /// let mut g = MultiPortGraph::new();
+    /// let a = g.add_node(0, 2);
+    /// let b = g.add_node(2, 0);
+    ///
+    /// g.link_nodes(a, 0, b, 0).unwrap();
+    ///
+    /// assert!(g.connected(a, b));
+    /// ```
+    #[must_use]
+    #[inline]
+    fn connected(&self, from: NodeIndex, to: NodeIndex) -> bool {
+        self.get_connection(from, to).is_some()
+    }
+
+    /// Returns the direction of the `port`.
+    #[must_use]
+    fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction>;
+
+    /// Returns the node that the `port` belongs to.
+    #[must_use]
+    fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
+
+    /// Returns the index of a `port` within its node's port list.
+    #[must_use]
+    fn port_offset(&self, port: impl Into<PortIndex>) -> Option<PortOffset>;
+
+    /// Returns the port index for a given node, direction, and offset.
+    #[must_use]
+    fn port_index(&self, node: NodeIndex, offset: PortOffset) -> Option<PortIndex>;
+
+    /// Returns the port that the given `port` is linked to.
+    #[must_use]
+    fn port_links(&self, port: PortIndex) -> Self::PortLinks<'_>;
+
+    /// Return the link to the provided port, if not connected return None.
+    /// If this port has multiple connected subports, an arbitrary one is returned.
+    #[must_use]
+    #[inline]
+    fn port_link(&self, port: PortIndex) -> Option<Self::SubportIndex> {
+        self.port_links(port).next().map(|(_, p)| p)
+    }
+
+    /// Return the subport linked to the given `port`. If the port is not
+    /// connected, return None.
+    #[must_use]
+    fn subport_link(&self, subport: Self::SubportIndex) -> Option<Self::SubportIndex>;
+
+    /// Iterates over all the ports of the `node` in the given `direction`.
+    #[must_use]
+    fn ports(&self, node: NodeIndex, direction: Direction) -> Self::NodePorts<'_>;
+
+    /// Iterates over the input and output ports of the `node` in sequence.
+    #[must_use]
+    fn all_ports(&self, node: NodeIndex) -> Self::NodePorts<'_>;
+
+    /// Returns the input port at the given offset in the `node`.
+    ///
+    /// Shorthand for [`MultiView::port_index`].
+    #[must_use]
+    fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
+
+    /// Returns the output port at the given offset in the `node`.
+    ///
+    /// Shorthand for [`MultiView::port_index`].
+    #[must_use]
+    fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
+
+    /// Iterates over all the input ports of the `node`.
+    ///
+    /// Shorthand for [`MultiView::ports`].
+    #[must_use]
+    fn inputs(&self, node: NodeIndex) -> Self::NodePorts<'_>;
+
+    /// Iterates over all the output ports of the `node`.
+    ///
+    /// Shorthand for [`MultiView::ports`].
+    #[must_use]
+    fn outputs(&self, node: NodeIndex) -> Self::NodePorts<'_>;
+
+    /// Returns the number of input ports of the `node`.
+    ///
+    /// Shorthand for [`MultiView::num_ports`].
+    #[must_use]
+    #[inline]
+    fn num_inputs(&self, node: NodeIndex) -> usize {
+        self.num_ports(node, Direction::Incoming)
+    }
+
+    /// Returns the number of output ports of the `node`.
+    ///
+    /// Shorthand for [`MultiView::num_ports`].
+    #[must_use]
+    #[inline]
+    fn num_outputs(&self, node: NodeIndex) -> usize {
+        self.num_ports(node, Direction::Outgoing)
+    }
+
+    /// Returns the number of ports of the `node` in the given `direction`.
+    #[must_use]
+    fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
+
+    /// Iterates over all the ports of the `node` in the given `direction`.
+    #[must_use]
+    fn subports(&self, node: NodeIndex, direction: Direction) -> Self::NodeSubports<'_>;
+
+    /// Iterates over the input and output ports of the `node` in sequence.
+    #[must_use]
+    fn all_subports(&self, node: NodeIndex) -> Self::NodeSubports<'_>;
+
+    /// Iterates over all the input ports of the `node`.
+    ///
+    /// Shorthand for [`MultiView::subports`].
+    #[must_use]
+    #[inline]
+    fn subport_inputs(&self, node: NodeIndex) -> Self::NodeSubports<'_> {
+        self.subports(node, Direction::Incoming)
+    }
+
+    /// Iterates over all the output ports of the `node`.
+    ///
+    /// Shorthand for [`MultiView::subports`].
+    #[must_use]
+    #[inline]
+    fn subport_outputs(&self, node: NodeIndex) -> Self::NodeSubports<'_> {
+        self.subports(node, Direction::Outgoing)
+    }
+
+    /// Iterates over all the port offsets of the `node` in the given `direction`.
+    #[must_use]
+    fn port_offsets(&self, node: NodeIndex, direction: Direction) -> Self::NodePortOffsets<'_>;
+
+    /// Iterates over the input and output port offsets of the `node` in sequence.
+    #[must_use]
+    fn all_port_offsets(&self, node: NodeIndex) -> Self::NodePortOffsets<'_>;
+
+    /// Iterates over all the input port offsets of the `node`.
+    ///
+    /// Shorthand for [`MultiView::port_offsets`].
+    #[must_use]
+    #[inline]
+    fn input_offsets(&self, node: NodeIndex) -> Self::NodePortOffsets<'_> {
+        self.port_offsets(node, Direction::Incoming)
+    }
+
+    /// Iterates over all the output port offsets of the `node`.
+    ///
+    /// Shorthand for [`MultiView::port_offsets`].
+    #[must_use]
+    #[inline]
+    fn output_offsets(&self, node: NodeIndex) -> Self::NodePortOffsets<'_> {
+        self.port_offsets(node, Direction::Outgoing)
+    }
+
+    /// Iterates over the connected links of the `node` in the given
+    /// `direction`.
+    ///
+    /// In contrast to [`PortGraph::links`], this iterator only returns linked
+    /// subports, and includes the source subport.
+    ///
+    /// [`PortGraph::links`]: portgraph::PortGraph::links
+    #[must_use]
+    fn links(&self, node: NodeIndex, direction: Direction) -> Self::NodeLinks<'_>;
+
+    /// Iterates over the connected input and output links of the `node` in sequence.
+    #[must_use]
+    fn all_links(&self, node: NodeIndex) -> Self::NodeLinks<'_>;
+
+    /// Iterates over the connected input links of the `node`. Shorthand for
+    /// [`MultiView::links`].
+    #[must_use]
+    #[inline]
+    fn input_links(&self, node: NodeIndex) -> Self::NodeLinks<'_> {
+        self.links(node, Direction::Incoming)
+    }
+
+    /// Iterates over the connected output links of the `node`. Shorthand for
+    /// [`MultiView::links`].
+    #[must_use]
+    #[inline]
+    fn output_links(&self, node: NodeIndex) -> Self::NodeLinks<'_> {
+        self.links(node, Direction::Outgoing)
+    }
+
+    /// Iterates over neighbour nodes in the given `direction`.
+    /// May contain duplicates if the graph has multiple links between nodes.
+    #[must_use]
+    fn neighbours(&self, node: NodeIndex, direction: Direction) -> Self::Neighbours<'_>;
+
+    /// Iterates over the input and output neighbours of the `node` in sequence.
+    #[must_use]
+    fn all_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_>;
+
+    /// Iterates over the input neighbours of the `node`. Shorthand for [`MultiView::neighbours`].
+    #[must_use]
+    #[inline]
+    fn input_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_> {
+        self.neighbours(node, Direction::Incoming)
+    }
+
+    /// Iterates over the output neighbours of the `node`. Shorthand for [`MultiView::neighbours`].
+    #[must_use]
+    #[inline]
+    fn output_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_> {
+        self.neighbours(node, Direction::Outgoing)
+    }
+
+    /// Returns whether the port graph contains the `node`.
+    #[must_use]
+    fn contains_node(&self, node: NodeIndex) -> bool;
+
+    /// Returns whether the port graph contains the `port`.
+    #[must_use]
+    fn contains_port(&self, port: PortIndex) -> bool;
+
+    /// Returns whether the port graph has no nodes nor ports.
+    #[must_use]
+    fn is_empty(&self) -> bool;
+
+    /// Returns the number of nodes in the port graph.
+    #[must_use]
+    fn node_count(&self) -> usize;
+
+    /// Returns the number of ports in the port graph.
+    #[must_use]
+    fn port_count(&self) -> usize;
+
+    /// Returns the number of links between ports.
+    #[must_use]
+    fn link_count(&self) -> usize;
+
+    /// Iterates over the nodes in the port graph.
+    #[must_use]
+    fn nodes_iter(&self) -> Self::Nodes<'_>;
+
+    /// Iterates over the ports in the port graph.
+    #[must_use]
+    fn ports_iter(&self) -> Self::Ports<'_>;
+
+    /// Removes all nodes and ports from the port graph.
+    fn clear(&mut self);
+
+    /// Returns the capacity of the underlying buffer for nodes.
+    #[must_use]
+    fn node_capacity(&self) -> usize;
+
+    /// Returns the capacity of the underlying buffer for ports.
+    #[must_use]
+    fn port_capacity(&self) -> usize;
+
+    /// Returns the allocated port capacity for a specific node.
+    ///
+    /// Changes to the number of ports of the node will not reallocate
+    /// until the number of ports exceeds this capacity.
+    #[must_use]
+    fn node_port_capacity(&self, node: NodeIndex) -> usize;
+
+    /// Reserves enough capacity to insert at least the given number of additional nodes and ports.
+    ///
+    /// This method does not take into account the length of the free list and might overallocate speculatively.
+    fn reserve(&mut self, nodes: usize, ports: usize);
+
+    /// Changes the number of ports of the `node` to the given `incoming` and `outgoing` counts.
+    ///
+    /// Invalidates the indices of the node's ports. If the number of incoming or outgoing ports
+    /// is reduced, the ports are removed from the end of the port list.
+    ///
+    /// Every time a port is moved, the `rekey` function will be called with its old and new index.
+    /// If the port is removed, the new index will be `None`.
+    ///
+    /// This operation is O(n) where n is the number of ports of the node.
+    fn set_num_ports<F>(&mut self, node: NodeIndex, incoming: usize, outgoing: usize, rekey: F)
+    where
+        F: FnMut(PortIndex, PortOperation);
+
+    /// Compacts the storage of nodes in the portgraph as much as possible. Note
+    /// that node indices won't necessarily be consecutive after this process.
+    ///
+    /// Every time a node is moved, the `rekey` function will be called with its
+    /// old and new index.
+    fn compact_nodes<F>(&mut self, rekey: F)
+    where
+        F: FnMut(NodeIndex, NodeIndex);
+
+    /// Compacts the storage of ports in the portgraph as much as possible. Note
+    /// that indices won't necessarily be consecutive after this process.
+    ///
+    /// Every time a port is moved, the `rekey` function will be called with is
+    /// old and new index.
+    fn compact_ports<F>(&mut self, rekey: F)
+    where
+        F: FnMut(PortIndex, PortIndex);
+
+    /// Shrinks the underlying buffers to the fit the data.
+    ///
+    /// This does not alter existing indices.
+    fn shrink_to_fit(&mut self);
+}

--- a/src/view.rs
+++ b/src/view.rs
@@ -19,7 +19,7 @@ pub trait PortView {
     where
         Self: 'a;
 
-    /// Iterator over the sub ports of each port in a node.
+    /// Iterator over the port offsets in a node.
     type NodePortOffsets<'a>: Iterator<Item = PortOffset>
     where
         Self: 'a;

--- a/src/view.rs
+++ b/src/view.rs
@@ -2,11 +2,8 @@
 
 use crate::{portgraph::PortOperation, Direction, LinkError, NodeIndex, PortIndex, PortOffset};
 
-/// Abstraction over a portgraph that may have multiple connections per node.
-pub trait MultiView {
-    /// An index type used to identify specific connections in a multiport.
-    type SubportIndex;
-
+/// Core capabilities of a graph containing nodes and ports.
+pub trait PortView {
     /// Iterator over the nodes of the graph.
     type Nodes<'a>: Iterator<Item = NodeIndex>
     where
@@ -23,34 +20,7 @@ pub trait MultiView {
         Self: 'a;
 
     /// Iterator over the sub ports of each port in a node.
-    type NodeSubports<'a>: Iterator<Item = Self::SubportIndex>
-    where
-        Self: 'a;
-
-    /// Iterator over the sub ports of each port in a node.
     type NodePortOffsets<'a>: Iterator<Item = PortOffset>
-    where
-        Self: 'a;
-
-    /// Iterator over the connections between two nodes.
-    type NodeConnections<'a>: Iterator<Item = (Self::SubportIndex, Self::SubportIndex)>
-    where
-        Self: 'a;
-
-    /// Iterator over the links of a node. Returns pairs of source subport in
-    /// the given node and target subport in the linked node.
-    type NodeLinks<'a>: Iterator<Item = (Self::SubportIndex, Self::SubportIndex)>
-    where
-        Self: 'a;
-
-    /// Iterator over the links of a port. Returns pairs of source subport in
-    /// the given ports and target subport in the linked port.
-    type PortLinks<'a>: Iterator<Item = (Self::SubportIndex, Self::SubportIndex)>
-    where
-        Self: 'a;
-
-    /// Iterator over the neighbours of a node.
-    type Neighbours<'a>: Iterator<Item = NodeIndex>
     where
         Self: 'a;
 
@@ -64,7 +34,7 @@ pub trait MultiView {
     ///
     /// ```
     /// # use portgraph::multiportgraph::MultiPortGraph;
-    /// # use portgraph::{Direction, MultiView};
+    /// # use portgraph::{Direction, PortView, LinkView, MultiView};
     /// let mut g = MultiPortGraph::new();
     /// let node = g.add_node(4, 3);
     /// assert_eq!(g.inputs(node).count(), 4);
@@ -80,7 +50,7 @@ pub trait MultiView {
     ///
     /// ```
     /// # use portgraph::multiportgraph::MultiPortGraph;
-    /// # use portgraph::{Direction, MultiView};
+    /// # use portgraph::{Direction, PortView, LinkView, MultiView};
     /// let mut g = MultiPortGraph::new();
     /// let node0 = g.add_node(1, 1);
     /// let node1 = g.add_node(1, 1);
@@ -92,175 +62,6 @@ pub trait MultiView {
     /// assert!(g.port_link(g.inputs(node1).nth(0).unwrap()).is_none());
     /// ```
     fn remove_node(&mut self, node: NodeIndex);
-
-    /// Link an output port to an input port.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use portgraph::multiportgraph::MultiPortGraph;
-    /// # use portgraph::{Direction, MultiView};
-    /// let mut g = MultiPortGraph::new();
-    /// let node0 = g.add_node(0, 1);
-    /// let node1 = g.add_node(1, 0);
-    /// let node0_output = g.output(node0, 0).unwrap();
-    /// let node1_input = g.input(node1, 0).unwrap();
-    /// g.link_ports(node0_output, node1_input).unwrap();
-    /// assert_eq!(g.port_link(node0_output).unwrap().port(), node1_input);
-    /// assert_eq!(g.port_link(node1_input).unwrap().port(), node0_output);
-    /// ```
-    ///
-    /// # Errors
-    ///
-    ///  - If `port_a` or `port_b` does not exist.
-    ///  - If `port_a` and `port_b` have the same direction.
-    fn link_ports(
-        &mut self,
-        port_a: PortIndex,
-        port_b: PortIndex,
-    ) -> Result<(Self::SubportIndex, Self::SubportIndex), LinkError>;
-
-    /// Link an output subport to an input subport.
-    ///
-    /// # Errors
-    ///
-    ///  - If `subport_from` or `subport_to` does not exist.
-    ///  - If `subport_a` and `subport_b` have the same direction.
-    ///  - If `subport_from` or `subport_to` is already linked.
-    fn link_subports(
-        &mut self,
-        subport_from: Self::SubportIndex,
-        subport_to: Self::SubportIndex,
-    ) -> Result<(), LinkError>;
-
-    /// Links two nodes at an input and output port offsets.
-    ///
-    /// # Errors
-    ///
-    ///  - If the ports and nodes do not exist.
-    fn link_nodes(
-        &mut self,
-        from: NodeIndex,
-        from_output: usize,
-        to: NodeIndex,
-        to_input: usize,
-    ) -> Result<(Self::SubportIndex, Self::SubportIndex), LinkError> {
-        self.link_offsets(
-            from,
-            PortOffset::new_outgoing(from_output),
-            to,
-            PortOffset::new_incoming(to_input),
-        )
-    }
-
-    /// Links two nodes at an input and output port offsets.
-    ///
-    /// # Errors
-    ///
-    ///  - If the ports and nodes do not exist.
-    ///  - If the ports have the same direction.
-    fn link_offsets(
-        &mut self,
-        node_a: NodeIndex,
-        offset_a: PortOffset,
-        node_b: NodeIndex,
-        offset_b: PortOffset,
-    ) -> Result<(Self::SubportIndex, Self::SubportIndex), LinkError> {
-        let from_port = self
-            .port_index(node_a, offset_a)
-            .ok_or(LinkError::UnknownOffset {
-                node: node_a,
-                offset: offset_a,
-            })?;
-        let to_port = self
-            .port_index(node_b, offset_b)
-            .ok_or(LinkError::UnknownOffset {
-                node: node_b,
-                offset: offset_b,
-            })?;
-        self.link_ports(from_port, to_port)
-    }
-
-    /// Unlinks all connections to the `port`. Return `false` if the port was not linked.
-    fn unlink_port(&mut self, port: PortIndex) -> bool;
-
-    /// Unlinks the `port` and returns the port it was linked to. Returns `None`
-    /// when the port was not linked.
-    fn unlink_subport(&mut self, subport: Self::SubportIndex) -> Option<Self::SubportIndex>;
-
-    /// Returns an iterator over every pair of matching ports connecting `from`
-    /// with `to`.
-    ///
-    /// # Example
-    /// ```
-    /// # use portgraph::multiportgraph::{MultiPortGraph, SubportIndex};
-    /// # use portgraph::{NodeIndex, PortIndex, Direction, MultiView};
-    /// # use itertools::Itertools;
-    /// let mut g = MultiPortGraph::new();
-    /// let a = g.add_node(0, 2);
-    /// let b = g.add_node(2, 0);
-    ///
-    /// g.link_nodes(a, 0, b, 0).unwrap();
-    /// g.link_nodes(a, 0, b, 1).unwrap();
-    /// g.link_nodes(a, 1, b, 1).unwrap();
-    ///
-    /// let mut connections = g.get_connections(a, b);
-    /// let (out0, out1) = g.outputs(a).collect_tuple().unwrap();
-    /// let (in0, in1) = g.inputs(b).collect_tuple().unwrap();
-    /// assert_eq!(connections.next().unwrap(), (SubportIndex::new_multi(out0,0), SubportIndex::new_multi(in0,0)));
-    /// assert_eq!(connections.next().unwrap(), (SubportIndex::new_multi(out0,1), SubportIndex::new_multi(in1,0)));
-    /// assert_eq!(connections.next().unwrap(), (SubportIndex::new_multi(out1,0), SubportIndex::new_multi(in1,1)));
-    /// assert_eq!(connections.next(), None);
-    /// ```
-    #[must_use]
-    fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> Self::NodeConnections<'_>;
-
-    /// Checks whether there is a directed link between the two nodes and
-    /// returns the first matching pair of ports.
-    ///
-    /// # Example
-    /// ```
-    /// # use portgraph::multiportgraph::{MultiPortGraph, SubportIndex};
-    /// # use portgraph::{NodeIndex, PortIndex, Direction, MultiView};
-    /// let mut g = MultiPortGraph::new();
-    /// let a = g.add_node(0, 2);
-    /// let b = g.add_node(2, 0);
-    ///
-    /// g.link_nodes(a, 0, b, 0).unwrap();
-    /// g.link_nodes(a, 1, b, 1).unwrap();
-    ///
-    /// let out0 = g.output(a, 0).unwrap();
-    /// let in0 = g.input(b, 0).unwrap();
-    /// assert_eq!(g.get_connection(a, b), Some((SubportIndex::new_multi(out0,0), SubportIndex::new_multi(in0,0))));
-    /// ```
-    #[must_use]
-    fn get_connection(
-        &self,
-        from: NodeIndex,
-        to: NodeIndex,
-    ) -> Option<(Self::SubportIndex, Self::SubportIndex)> {
-        self.get_connections(from, to).next()
-    }
-
-    /// Checks whether there is a directed link between the two nodes.
-    ///
-    /// # Example
-    /// ```
-    /// # use portgraph::multiportgraph::MultiPortGraph;
-    /// # use portgraph::{NodeIndex, PortIndex, Direction, MultiView};
-    /// let mut g = MultiPortGraph::new();
-    /// let a = g.add_node(0, 2);
-    /// let b = g.add_node(2, 0);
-    ///
-    /// g.link_nodes(a, 0, b, 0).unwrap();
-    ///
-    /// assert!(g.connected(a, b));
-    /// ```
-    #[must_use]
-    #[inline]
-    fn connected(&self, from: NodeIndex, to: NodeIndex) -> bool {
-        self.get_connection(from, to).is_some()
-    }
 
     /// Returns the direction of the `port`.
     #[must_use]
@@ -278,23 +79,6 @@ pub trait MultiView {
     #[must_use]
     fn port_index(&self, node: NodeIndex, offset: PortOffset) -> Option<PortIndex>;
 
-    /// Returns the port that the given `port` is linked to.
-    #[must_use]
-    fn port_links(&self, port: PortIndex) -> Self::PortLinks<'_>;
-
-    /// Return the link to the provided port, if not connected return None.
-    /// If this port has multiple connected subports, an arbitrary one is returned.
-    #[must_use]
-    #[inline]
-    fn port_link(&self, port: PortIndex) -> Option<Self::SubportIndex> {
-        self.port_links(port).next().map(|(_, p)| p)
-    }
-
-    /// Return the subport linked to the given `port`. If the port is not
-    /// connected, return None.
-    #[must_use]
-    fn subport_link(&self, subport: Self::SubportIndex) -> Option<Self::SubportIndex>;
-
     /// Iterates over all the ports of the `node` in the given `direction`.
     #[must_use]
     fn ports(&self, node: NodeIndex, direction: Direction) -> Self::NodePorts<'_>;
@@ -305,31 +89,31 @@ pub trait MultiView {
 
     /// Returns the input port at the given offset in the `node`.
     ///
-    /// Shorthand for [`MultiView::port_index`].
+    /// Shorthand for [`PortView::port_index`].
     #[must_use]
     fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
 
     /// Returns the output port at the given offset in the `node`.
     ///
-    /// Shorthand for [`MultiView::port_index`].
+    /// Shorthand for [`PortView::port_index`].
     #[must_use]
     fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
 
     /// Iterates over all the input ports of the `node`.
     ///
-    /// Shorthand for [`MultiView::ports`].
+    /// Shorthand for [`PortView::ports`].
     #[must_use]
     fn inputs(&self, node: NodeIndex) -> Self::NodePorts<'_>;
 
     /// Iterates over all the output ports of the `node`.
     ///
-    /// Shorthand for [`MultiView::ports`].
+    /// Shorthand for [`PortView::ports`].
     #[must_use]
     fn outputs(&self, node: NodeIndex) -> Self::NodePorts<'_>;
 
     /// Returns the number of input ports of the `node`.
     ///
-    /// Shorthand for [`MultiView::num_ports`].
+    /// Shorthand for [`PortView::num_ports`].
     #[must_use]
     #[inline]
     fn num_inputs(&self, node: NodeIndex) -> usize {
@@ -338,7 +122,7 @@ pub trait MultiView {
 
     /// Returns the number of output ports of the `node`.
     ///
-    /// Shorthand for [`MultiView::num_ports`].
+    /// Shorthand for [`PortView::num_ports`].
     #[must_use]
     #[inline]
     fn num_outputs(&self, node: NodeIndex) -> usize {
@@ -348,32 +132,6 @@ pub trait MultiView {
     /// Returns the number of ports of the `node` in the given `direction`.
     #[must_use]
     fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
-
-    /// Iterates over all the ports of the `node` in the given `direction`.
-    #[must_use]
-    fn subports(&self, node: NodeIndex, direction: Direction) -> Self::NodeSubports<'_>;
-
-    /// Iterates over the input and output ports of the `node` in sequence.
-    #[must_use]
-    fn all_subports(&self, node: NodeIndex) -> Self::NodeSubports<'_>;
-
-    /// Iterates over all the input ports of the `node`.
-    ///
-    /// Shorthand for [`MultiView::subports`].
-    #[must_use]
-    #[inline]
-    fn subport_inputs(&self, node: NodeIndex) -> Self::NodeSubports<'_> {
-        self.subports(node, Direction::Incoming)
-    }
-
-    /// Iterates over all the output ports of the `node`.
-    ///
-    /// Shorthand for [`MultiView::subports`].
-    #[must_use]
-    #[inline]
-    fn subport_outputs(&self, node: NodeIndex) -> Self::NodeSubports<'_> {
-        self.subports(node, Direction::Outgoing)
-    }
 
     /// Iterates over all the port offsets of the `node` in the given `direction`.
     #[must_use]
@@ -385,7 +143,7 @@ pub trait MultiView {
 
     /// Iterates over all the input port offsets of the `node`.
     ///
-    /// Shorthand for [`MultiView::port_offsets`].
+    /// Shorthand for [`PortView::port_offsets`].
     #[must_use]
     #[inline]
     fn input_offsets(&self, node: NodeIndex) -> Self::NodePortOffsets<'_> {
@@ -394,64 +152,11 @@ pub trait MultiView {
 
     /// Iterates over all the output port offsets of the `node`.
     ///
-    /// Shorthand for [`MultiView::port_offsets`].
+    /// Shorthand for [`PortView::port_offsets`].
     #[must_use]
     #[inline]
     fn output_offsets(&self, node: NodeIndex) -> Self::NodePortOffsets<'_> {
         self.port_offsets(node, Direction::Outgoing)
-    }
-
-    /// Iterates over the connected links of the `node` in the given
-    /// `direction`.
-    ///
-    /// In contrast to [`PortGraph::links`], this iterator only returns linked
-    /// subports, and includes the source subport.
-    ///
-    /// [`PortGraph::links`]: portgraph::PortGraph::links
-    #[must_use]
-    fn links(&self, node: NodeIndex, direction: Direction) -> Self::NodeLinks<'_>;
-
-    /// Iterates over the connected input and output links of the `node` in sequence.
-    #[must_use]
-    fn all_links(&self, node: NodeIndex) -> Self::NodeLinks<'_>;
-
-    /// Iterates over the connected input links of the `node`. Shorthand for
-    /// [`MultiView::links`].
-    #[must_use]
-    #[inline]
-    fn input_links(&self, node: NodeIndex) -> Self::NodeLinks<'_> {
-        self.links(node, Direction::Incoming)
-    }
-
-    /// Iterates over the connected output links of the `node`. Shorthand for
-    /// [`MultiView::links`].
-    #[must_use]
-    #[inline]
-    fn output_links(&self, node: NodeIndex) -> Self::NodeLinks<'_> {
-        self.links(node, Direction::Outgoing)
-    }
-
-    /// Iterates over neighbour nodes in the given `direction`.
-    /// May contain duplicates if the graph has multiple links between nodes.
-    #[must_use]
-    fn neighbours(&self, node: NodeIndex, direction: Direction) -> Self::Neighbours<'_>;
-
-    /// Iterates over the input and output neighbours of the `node` in sequence.
-    #[must_use]
-    fn all_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_>;
-
-    /// Iterates over the input neighbours of the `node`. Shorthand for [`MultiView::neighbours`].
-    #[must_use]
-    #[inline]
-    fn input_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_> {
-        self.neighbours(node, Direction::Incoming)
-    }
-
-    /// Iterates over the output neighbours of the `node`. Shorthand for [`MultiView::neighbours`].
-    #[must_use]
-    #[inline]
-    fn output_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_> {
-        self.neighbours(node, Direction::Outgoing)
     }
 
     /// Returns whether the port graph contains the `node`.
@@ -473,10 +178,6 @@ pub trait MultiView {
     /// Returns the number of ports in the port graph.
     #[must_use]
     fn port_count(&self) -> usize;
-
-    /// Returns the number of links between ports.
-    #[must_use]
-    fn link_count(&self) -> usize;
 
     /// Iterates over the nodes in the port graph.
     #[must_use]
@@ -544,4 +245,307 @@ pub trait MultiView {
     ///
     /// This does not alter existing indices.
     fn shrink_to_fit(&mut self);
+}
+
+/// Operations pertaining the adjacency of nodes in a port graph.
+pub trait LinkView: PortView {
+    /// The identifier for the endpoints of a link.
+    type LinkEndpoint: Into<PortIndex>;
+
+    /// Iterator over the neighbours of a node.
+    type Neighbours<'a>: Iterator<Item = NodeIndex>
+    where
+        Self: 'a;
+
+    /// Iterator over the connections between two nodes.
+    type NodeConnections<'a>: Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>
+    where
+        Self: 'a;
+
+    /// Iterator over the links of a node. Returns pairs of source subport in
+    /// the given node and target subport in the linked node.
+    type NodeLinks<'a>: Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>
+    where
+        Self: 'a;
+
+    /// Iterator over the links of a port. Returns pairs of source subport in
+    /// the given ports and target subport in the linked port.
+    type PortLinks<'a>: Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>
+    where
+        Self: 'a;
+
+    /// Link an output port to an input port.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use portgraph::multiportgraph::MultiPortGraph;
+    /// # use portgraph::{Direction, PortView, LinkView, MultiView};
+    /// let mut g = MultiPortGraph::new();
+    /// let node0 = g.add_node(0, 1);
+    /// let node1 = g.add_node(1, 0);
+    /// let node0_output = g.output(node0, 0).unwrap();
+    /// let node1_input = g.input(node1, 0).unwrap();
+    /// g.link_ports(node0_output, node1_input).unwrap();
+    /// assert_eq!(g.port_link(node0_output).unwrap().port(), node1_input);
+    /// assert_eq!(g.port_link(node1_input).unwrap().port(), node0_output);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    ///  - If `port_a` or `port_b` does not exist.
+    ///  - If `port_a` and `port_b` have the same direction.
+    fn link_ports(
+        &mut self,
+        port_a: PortIndex,
+        port_b: PortIndex,
+    ) -> Result<(Self::LinkEndpoint, Self::LinkEndpoint), LinkError>;
+
+    /// Links two nodes at an input and output port offsets.
+    ///
+    /// # Errors
+    ///
+    ///  - If the ports and nodes do not exist.
+    fn link_nodes(
+        &mut self,
+        from: NodeIndex,
+        from_output: usize,
+        to: NodeIndex,
+        to_input: usize,
+    ) -> Result<(Self::LinkEndpoint, Self::LinkEndpoint), LinkError> {
+        self.link_offsets(
+            from,
+            PortOffset::new_outgoing(from_output),
+            to,
+            PortOffset::new_incoming(to_input),
+        )
+    }
+
+    /// Links two nodes at an input and output port offsets.
+    ///
+    /// # Errors
+    ///
+    ///  - If the ports and nodes do not exist.
+    ///  - If the ports have the same direction.
+    fn link_offsets(
+        &mut self,
+        node_a: NodeIndex,
+        offset_a: PortOffset,
+        node_b: NodeIndex,
+        offset_b: PortOffset,
+    ) -> Result<(Self::LinkEndpoint, Self::LinkEndpoint), LinkError> {
+        let from_port = self
+            .port_index(node_a, offset_a)
+            .ok_or(LinkError::UnknownOffset {
+                node: node_a,
+                offset: offset_a,
+            })?;
+        let to_port = self
+            .port_index(node_b, offset_b)
+            .ok_or(LinkError::UnknownOffset {
+                node: node_b,
+                offset: offset_b,
+            })?;
+        self.link_ports(from_port, to_port)
+    }
+
+    /// Unlinks all connections to the `port`. Return `false` if the port was not linked.
+    fn unlink_port(&mut self, port: PortIndex) -> bool;
+
+    /// Returns an iterator over every pair of matching ports connecting `from`
+    /// with `to`.
+    ///
+    /// # Example
+    /// ```
+    /// # use portgraph::multiportgraph::{MultiPortGraph, SubportIndex};
+    /// # use portgraph::{NodeIndex, PortIndex, Direction, PortView, LinkView, MultiView};
+    /// # use itertools::Itertools;
+    /// let mut g = MultiPortGraph::new();
+    /// let a = g.add_node(0, 2);
+    /// let b = g.add_node(2, 0);
+    ///
+    /// g.link_nodes(a, 0, b, 0).unwrap();
+    /// g.link_nodes(a, 0, b, 1).unwrap();
+    /// g.link_nodes(a, 1, b, 1).unwrap();
+    ///
+    /// let mut connections = g.get_connections(a, b);
+    /// let (out0, out1) = g.outputs(a).collect_tuple().unwrap();
+    /// let (in0, in1) = g.inputs(b).collect_tuple().unwrap();
+    /// assert_eq!(connections.next().unwrap(), (SubportIndex::new_multi(out0,0), SubportIndex::new_multi(in0,0)));
+    /// assert_eq!(connections.next().unwrap(), (SubportIndex::new_multi(out0,1), SubportIndex::new_multi(in1,0)));
+    /// assert_eq!(connections.next().unwrap(), (SubportIndex::new_multi(out1,0), SubportIndex::new_multi(in1,1)));
+    /// assert_eq!(connections.next(), None);
+    /// ```
+    #[must_use]
+    fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> Self::NodeConnections<'_>;
+
+    /// Checks whether there is a directed link between the two nodes and
+    /// returns the first matching pair of ports.
+    ///
+    /// # Example
+    /// ```
+    /// # use portgraph::multiportgraph::{MultiPortGraph, SubportIndex};
+    /// # use portgraph::{NodeIndex, PortIndex, Direction, PortView, LinkView, MultiView};
+    /// let mut g = MultiPortGraph::new();
+    /// let a = g.add_node(0, 2);
+    /// let b = g.add_node(2, 0);
+    ///
+    /// g.link_nodes(a, 0, b, 0).unwrap();
+    /// g.link_nodes(a, 1, b, 1).unwrap();
+    ///
+    /// let out0 = g.output(a, 0).unwrap();
+    /// let in0 = g.input(b, 0).unwrap();
+    /// assert_eq!(g.get_connection(a, b), Some((SubportIndex::new_multi(out0,0), SubportIndex::new_multi(in0,0))));
+    /// ```
+    #[must_use]
+    fn get_connection(
+        &self,
+        from: NodeIndex,
+        to: NodeIndex,
+    ) -> Option<(Self::LinkEndpoint, Self::LinkEndpoint)> {
+        self.get_connections(from, to).next()
+    }
+
+    /// Checks whether there is a directed link between the two nodes.
+    ///
+    /// # Example
+    /// ```
+    /// # use portgraph::multiportgraph::MultiPortGraph;
+    /// # use portgraph::{NodeIndex, PortIndex, Direction, PortView, LinkView, MultiView};
+    /// let mut g = MultiPortGraph::new();
+    /// let a = g.add_node(0, 2);
+    /// let b = g.add_node(2, 0);
+    ///
+    /// g.link_nodes(a, 0, b, 0).unwrap();
+    ///
+    /// assert!(g.connected(a, b));
+    /// ```
+    #[must_use]
+    #[inline]
+    fn connected(&self, from: NodeIndex, to: NodeIndex) -> bool {
+        self.get_connection(from, to).is_some()
+    }
+
+    /// Returns the port that the given `port` is linked to.
+    #[must_use]
+    fn port_links(&self, port: PortIndex) -> Self::PortLinks<'_>;
+
+    /// Return the link to the provided port, if not connected return None.
+    /// If this port has multiple connected subports, an arbitrary one is returned.
+    #[must_use]
+    #[inline]
+    fn port_link(&self, port: PortIndex) -> Option<Self::LinkEndpoint> {
+        self.port_links(port).next().map(|(_, p)| p)
+    }
+
+    /// Iterates over the connected links of the `node` in the given
+    /// `direction`.
+    #[must_use]
+    fn links(&self, node: NodeIndex, direction: Direction) -> Self::NodeLinks<'_>;
+
+    /// Iterates over the connected input and output links of the `node` in sequence.
+    #[must_use]
+    fn all_links(&self, node: NodeIndex) -> Self::NodeLinks<'_>;
+
+    /// Iterates over the connected input links of the `node`. Shorthand for
+    /// [`LinkView::links`].
+    #[must_use]
+    #[inline]
+    fn input_links(&self, node: NodeIndex) -> Self::NodeLinks<'_> {
+        self.links(node, Direction::Incoming)
+    }
+
+    /// Iterates over the connected output links of the `node`. Shorthand for
+    /// [`LinkView::links`].
+    #[must_use]
+    #[inline]
+    fn output_links(&self, node: NodeIndex) -> Self::NodeLinks<'_> {
+        self.links(node, Direction::Outgoing)
+    }
+
+    /// Iterates over neighbour nodes in the given `direction`.
+    /// May contain duplicates if the graph has multiple links between nodes.
+    #[must_use]
+    fn neighbours(&self, node: NodeIndex, direction: Direction) -> Self::Neighbours<'_>;
+
+    /// Iterates over the input and output neighbours of the `node` in sequence.
+    #[must_use]
+    fn all_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_>;
+
+    /// Iterates over the input neighbours of the `node`. Shorthand for [`LinkView::neighbours`].
+    #[must_use]
+    #[inline]
+    fn input_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_> {
+        self.neighbours(node, Direction::Incoming)
+    }
+
+    /// Iterates over the output neighbours of the `node`. Shorthand for [`LinkView::neighbours`].
+    #[must_use]
+    #[inline]
+    fn output_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_> {
+        self.neighbours(node, Direction::Outgoing)
+    }
+
+    /// Returns the number of links between ports.
+    #[must_use]
+    fn link_count(&self) -> usize;
+}
+
+/// Abstraction over a portgraph that may have multiple connections per node.
+pub trait MultiView: LinkView {
+    /// An index type used to identify specific connections in a multiport.
+    type SubportIndex;
+
+    /// Iterator over the sub ports of each port in a node.
+    type NodeSubports<'a>: Iterator<Item = Self::SubportIndex>
+    where
+        Self: 'a;
+
+    /// Link an output subport to an input subport.
+    ///
+    /// # Errors
+    ///
+    ///  - If `subport_from` or `subport_to` does not exist.
+    ///  - If `subport_a` and `subport_b` have the same direction.
+    ///  - If `subport_from` or `subport_to` is already linked.
+    fn link_subports(
+        &mut self,
+        subport_from: Self::SubportIndex,
+        subport_to: Self::SubportIndex,
+    ) -> Result<(), LinkError>;
+
+    /// Unlinks the `port` and returns the port it was linked to. Returns `None`
+    /// when the port was not linked.
+    fn unlink_subport(&mut self, subport: Self::SubportIndex) -> Option<Self::SubportIndex>;
+
+    /// Return the subport linked to the given `port`. If the port is not
+    /// connected, return None.
+    #[must_use]
+    fn subport_link(&self, subport: Self::SubportIndex) -> Option<Self::SubportIndex>;
+
+    /// Iterates over all the ports of the `node` in the given `direction`.
+    #[must_use]
+    fn subports(&self, node: NodeIndex, direction: Direction) -> Self::NodeSubports<'_>;
+
+    /// Iterates over the input and output ports of the `node` in sequence.
+    #[must_use]
+    fn all_subports(&self, node: NodeIndex) -> Self::NodeSubports<'_>;
+
+    /// Iterates over all the input ports of the `node`.
+    ///
+    /// Shorthand for [`MultiView::subports`].
+    #[must_use]
+    #[inline]
+    fn subport_inputs(&self, node: NodeIndex) -> Self::NodeSubports<'_> {
+        self.subports(node, Direction::Incoming)
+    }
+
+    /// Iterates over all the output ports of the `node`.
+    ///
+    /// Shorthand for [`MultiView::subports`].
+    #[must_use]
+    #[inline]
+    fn subport_outputs(&self, node: NodeIndex) -> Self::NodeSubports<'_> {
+        self.subports(node, Direction::Outgoing)
+    }
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -543,7 +543,7 @@ pub trait MultiView: LinkView {
     /// An index type used to identify specific connections in a multiport.
     type SubportIndex;
 
-    /// Iterator over the sub ports of each port in a node.
+    /// Iterator over all the subports of a node.
     type NodeSubports<'a>: Iterator<Item = Self::SubportIndex>
     where
         Self: 'a;
@@ -561,7 +561,7 @@ pub trait MultiView: LinkView {
         subport_to: Self::SubportIndex,
     ) -> Result<(), LinkError>;
 
-    /// Unlinks the `port` and returns the port it was linked to. Returns `None`
+    /// Unlinks the `port` and returns the subport it was linked to. Returns `None`
     /// when the port was not linked.
     fn unlink_subport(&mut self, subport: Self::SubportIndex) -> Option<Self::SubportIndex>;
 
@@ -570,15 +570,15 @@ pub trait MultiView: LinkView {
     #[must_use]
     fn subport_link(&self, subport: Self::SubportIndex) -> Option<Self::SubportIndex>;
 
-    /// Iterates over all the ports of the `node` in the given `direction`.
+    /// Iterates over all the subports of the `node` in the given `direction`.
     #[must_use]
     fn subports(&self, node: NodeIndex, direction: Direction) -> Self::NodeSubports<'_>;
 
-    /// Iterates over the input and output ports of the `node` in sequence.
+    /// Iterates over the input and output subports of the `node` in sequence.
     #[must_use]
     fn all_subports(&self, node: NodeIndex) -> Self::NodeSubports<'_>;
 
-    /// Iterates over all the input ports of the `node`.
+    /// Iterates over all the input subports of the `node`.
     ///
     /// Shorthand for [`MultiView::subports`].
     #[must_use]
@@ -587,7 +587,7 @@ pub trait MultiView: LinkView {
         self.subports(node, Direction::Incoming)
     }
 
-    /// Iterates over all the output ports of the `node`.
+    /// Iterates over all the output subports of the `node`.
     ///
     /// Shorthand for [`MultiView::subports`].
     #[must_use]

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -11,7 +11,7 @@
 //! # Example
 //!
 //! ```
-//! # use portgraph::{PortGraph, NodeIndex, PortIndex};
+//! # use portgraph::{PortGraph, NodeIndex, PortIndex, PortView, LinkView};
 //! # use portgraph::weights::Weights;
 //! let mut graph = PortGraph::new();
 //! let mut weights = Weights::<usize, isize>::new();


### PR DESCRIPTION
Splits the interfaces between

- `PortView`: Core node and port manipulation.
- `LinkView`: Adjacency-related methods. It defines a `LinkEndpoint` associated type so MultiPortGraph can use `SubPortIndex` instead of `PortIndex`.
- `MultiView`: Subports and methods specific to multiportgraphs.

The functionality should remain unchanged, but this will allow us to better generalize the interfaces (algorithms, dot, ...) in the future.

It would make sense to add a `WeighView` trait too, but we don't need it at the moment so I'll just leave the issue for the future.