### PR TITLE
Implement dot rendering on LinkView trait

### DIFF
--- a/src/dot.rs
+++ b/src/dot.rs
@@ -220,6 +220,9 @@ where
     /// Outputs an html table row with the ports of a node.
     ///
     /// `num_others` is the number of ports in the other direction.
+    ///
+    /// The node table is a grid with `#inputs * #outputs` columns, so each port
+    /// label should be `num_others` columns wide.
     fn get_ports_row_dot(
         &mut self,
         node: NodeIndex,

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -76,214 +76,254 @@ impl EdgeStyle {
     }
 }
 
-/// Encode portgraph and `Hierarchy` in dot format.
-///
-/// Calls the `nodes` and `ports` functions to get the labels for the nodes and ports.
-/// The `ports` function also returns the style of the edge connected to a port.
-///
-/// Hierarchy relationships are shown as a separate tree of parent-child relationships
-pub fn hier_graph_dot_string_with<G: LinkView>(
-    graph: &G,
-    forest: &Hierarchy,
-    nodes: impl FnMut(NodeIndex) -> NodeStyle,
-    ports: impl FnMut(PortIndex) -> PortStyle,
-    edges: impl FnMut(G::LinkEndpoint, G::LinkEndpoint) -> EdgeStyle,
-) -> String {
-    let mut dot = String::new();
-
-    dot.push_str("digraph {\n");
-
-    node_and_edge_strings(graph, &mut dot, nodes, ports, edges);
-
-    let hier_node_id = |n: NodeIndex| format!("hier{}", n.index());
-
-    for n in graph.nodes_iter() {
-        let node_str = format!(
-            "{} [shape=plain label=\"{}\"]\n",
-            hier_node_id(n),
-            n.index()
-        );
-        dot.push_str(&node_str);
-
-        // Connect the parent to any existing children
-        forest.children(n).for_each(|child| {
-            dot.push_str(&{
-                let from_node = n;
-                let to_node = child;
-                format!(
-                    "{} -> {}  [style = \"dashed\"] \n",
-                    hier_node_id(from_node),
-                    hier_node_id(to_node),
-                )
-            });
-        });
-    }
-
-    dot.push_str("}\n");
-    dot
+/// Configurable dot formatter for a `PortGraph`.
+pub struct DotFormatter<'g, G: LinkView> {
+    graph: &'g G,
+    forest: Option<&'g Hierarchy>,
+    node_style: Option<Box<dyn FnMut(NodeIndex) -> NodeStyle + 'g>>,
+    port_style: Option<Box<dyn FnMut(PortIndex) -> PortStyle + 'g>>,
+    #[allow(clippy::type_complexity)]
+    edge_style: Option<Box<dyn FnMut(G::LinkEndpoint, G::LinkEndpoint) -> EdgeStyle + 'g>>,
 }
 
-/// Encode a portgraph and `Hierarchy` in dot format.
-pub fn hier_graph_dot_string(graph: &impl LinkView, hierarchy: &Hierarchy) -> String {
-    hier_graph_dot_string_with(
-        graph,
-        hierarchy,
-        |n| NodeStyle::new(n.index()),
-        |_| PortStyle::new(""),
-        |_, _| EdgeStyle::Solid,
-    )
-}
-
-/// Encode a portgraph in dot format.
-pub fn dot_string(graph: &impl LinkView) -> String {
-    dot_string_with(
-        graph,
-        |n| NodeStyle::new(n.index()),
-        |_| PortStyle::new(""),
-        |_, _| EdgeStyle::Solid,
-    )
-}
-
-/// Encode a portgraph in dot format.
-///
-/// Uses the `weights` to label the nodes and ports.
-pub fn dot_string_weighted<N, P>(graph: &impl LinkView, weights: &Weights<N, P>) -> String
+impl<'g, G> DotFormatter<'g, G>
 where
-    N: Display + Clone,
-    P: Display + Clone,
+    G: LinkView,
 {
-    dot_string_with(
-        graph,
-        |n| NodeStyle::new(&weights.nodes[n]),
-        |p| PortStyle::new(&weights.ports[p]),
-        |_, _| EdgeStyle::Solid,
-    )
-}
+    /// Initialize a new `DotFormatter` for `graph`.
+    pub fn new(graph: &'g G) -> Self {
+        Self {
+            graph,
+            forest: None,
+            node_style: None,
+            port_style: None,
+            edge_style: None,
+        }
+    }
 
-/// Encode a portgraph in dot format.
-///
-/// Calls the `nodes` and `ports` functions to get the labels for the nodes and ports.
-/// The `ports` function also returns the style of the edge connected to a port.
-pub fn dot_string_with<G: LinkView>(
-    graph: &G,
-    nodes: impl FnMut(NodeIndex) -> NodeStyle,
-    ports: impl FnMut(PortIndex) -> PortStyle,
-    edges: impl FnMut(G::LinkEndpoint, G::LinkEndpoint) -> EdgeStyle,
-) -> String {
-    let mut dot = String::new();
+    /// Set the `Hierarchy` to use for the graph.
+    pub fn with_hierarchy(mut self, forest: &'g Hierarchy) -> Self {
+        self.forest = Some(forest);
+        self
+    }
 
-    dot.push_str("digraph {\n");
-    node_and_edge_strings(graph, &mut dot, nodes, ports, edges);
-    dot.push_str("}\n");
-    dot
-}
+    /// Set the function to use to get the style of a node.
+    pub fn with_node_style(mut self, node_style: impl FnMut(NodeIndex) -> NodeStyle + 'g) -> Self {
+        self.node_style = Some(Box::new(node_style));
+        self
+    }
 
-/// Append the node and edge data in dot format to a string
-fn node_and_edge_strings<G: LinkView>(
-    graph: &G,
-    dot_str: &mut String,
-    mut nodes: impl FnMut(NodeIndex) -> NodeStyle,
-    mut ports: impl FnMut(PortIndex) -> PortStyle,
-    mut edges: impl FnMut(G::LinkEndpoint, G::LinkEndpoint) -> EdgeStyle,
-) {
-    for node in graph.nodes_iter() {
-        // Format the node as a table
-        let node_style = nodes(node);
-        let NodeStyle::Box(node_label) = node_style else {
-            // Ignore this node
-            continue;
+    /// Set the function to use to get the style of a port.
+    pub fn with_port_style(mut self, port_style: impl FnMut(PortIndex) -> PortStyle + 'g) -> Self {
+        self.port_style = Some(Box::new(port_style));
+        self
+    }
+
+    /// Set the function to use to get the style of an edge.
+    pub fn with_edge_style(
+        mut self,
+        edge_style: impl FnMut(G::LinkEndpoint, G::LinkEndpoint) -> EdgeStyle + 'g,
+    ) -> Self {
+        self.edge_style = Some(Box::new(edge_style));
+        self
+    }
+
+    /// Encode some `Weights` in the dot format.
+    pub fn with_weights<'w, N, P>(self, weights: &'w Weights<N, P>) -> Self
+    where
+        'w: 'g,
+        N: Display + Clone,
+        P: Display + Clone,
+    {
+        self.with_node_style(|n| NodeStyle::new(&weights.nodes[n]))
+            .with_port_style(|p| PortStyle::new(&weights.ports[p]))
+    }
+
+    /// Encode the graph in dot format.
+    pub fn finish(mut self) -> String {
+        let mut dot = String::new();
+
+        dot.push_str("digraph {\n");
+        self.node_and_edge_strings(&mut dot);
+        self.hierarchy_strings(&mut dot);
+        dot.push_str("}\n");
+
+        dot
+    }
+
+    /// Get the style of a node, using a default if none is set.
+    fn node_style(&mut self, node: NodeIndex) -> NodeStyle {
+        self.node_style
+            .as_mut()
+            .map(|f| f(node))
+            .unwrap_or_else(|| NodeStyle::new(node.index().to_string()))
+    }
+
+    /// Get the style of a port, using a default if none is set.
+    fn port_style(&mut self, port: PortIndex) -> PortStyle {
+        self.port_style
+            .as_mut()
+            .map(|f| f(port))
+            .unwrap_or_default()
+    }
+
+    /// Get the style of an edge, using a default if none is set.
+    fn edge_style(&mut self, src: G::LinkEndpoint, dst: G::LinkEndpoint) -> EdgeStyle {
+        self.edge_style
+            .as_mut()
+            .map(|f| f(src, dst))
+            .unwrap_or_default()
+    }
+
+    /// Append the node and edge data in dot format to a string
+    fn node_and_edge_strings(&mut self, dot: &mut String) {
+        for node in self.graph.nodes_iter() {
+            // Format the node as a table
+            let node_style = self.node_style(node);
+            let NodeStyle::Box(node_label) = node_style else {
+                // Ignore this node
+                continue;
+            };
+
+            // Track the port counts for spacing
+            let ins = self.graph.num_inputs(node).max(1);
+            let outs = self.graph.num_outputs(node).max(1);
+            let table_width = ins * outs;
+
+            let inputs_row = self.get_ports_row_dot(node, Direction::Incoming, outs);
+            let outputs_row = self.get_ports_row_dot(node, Direction::Outgoing, ins);
+
+            let label_row = format!(
+                "<tr><td align=\"text\" border=\"0\" colspan=\"{table_width}\">{node_label}</td></tr>"
+            );
+
+            let node_str = format!("{} [shape=plain label=<", node.index())
+                + "<table border=\"1\">"
+                + &inputs_row
+                + &label_row
+                + &outputs_row
+                + "</table>"
+                + ">]\n";
+            dot.push_str(&node_str);
+
+            // Connect the linked output ports
+            self.graph
+                .outputs(node)
+                .flat_map(|port| self.graph.port_links(port))
+                .map(|(from, to)| self.get_edge_dot(node, from, to))
+                .for_each(|edge| {
+                    dot.push_str(&edge);
+                });
+        }
+    }
+
+    /// Outputs an html table row with the ports of a node.
+    ///
+    /// `num_others` is the number of ports in the other direction.
+    fn get_ports_row_dot(
+        &mut self,
+        node: NodeIndex,
+        direction: Direction,
+        num_others: usize,
+    ) -> String {
+        if self.graph.num_ports(node, direction) == 0 {
+            return String::new();
+        }
+        let dir = match direction {
+            Direction::Incoming => "in",
+            Direction::Outgoing => "out",
         };
 
-        // Track the port counts for spacing
-        let ins = graph.num_inputs(node).max(1);
-        let outs = graph.num_outputs(node).max(1);
-        let table_width = ins * outs;
+        let separator = |label: &str| if label.is_empty() { "" } else { ": " };
 
-        let inputs_row = get_ports_row_dot(graph, node, Direction::Incoming, outs, &mut ports);
-        let outputs_row = get_ports_row_dot(graph, node, Direction::Outgoing, ins, &mut ports);
+        let mut ports_row = "<tr>".to_string();
+        for (offset, port) in self.graph.ports(node, direction).enumerate() {
+            let port_str = match self.port_style(port) {
+                PortStyle::Hidden =>
+                    format!("<td port=\"{dir}{offset}\" align=\"text\" colspan=\"0\"></td>"),
+                PortStyle::Text(label) =>
+                    format!("<td port=\"{dir}{offset}\" align=\"text\" colspan=\"{num_others}\">{offset}{separator}{label}</td>",
+                        separator = separator(&label),
+                    ),
+                PortStyle::Box(label) => format!(
+                        "<td port=\"{dir}{offset}\" align=\"text\" colspan=\"{num_others}\" cellpadding=\"1\">{offset}{separator}{label}</td>",
+                        separator = separator(&label),
+                    ),
+            };
+            ports_row.push_str(&port_str);
+        }
+        ports_row.push_str("</tr>");
+        ports_row
+    }
 
-        let label_row = format!(
-            "<tr><td align=\"text\" border=\"0\" colspan=\"{table_width}\">{node_label}</td></tr>"
-        );
+    /// If the port is linked, outputs the edge in dot format.
+    fn get_edge_dot(
+        &mut self,
+        from_node: NodeIndex,
+        from: G::LinkEndpoint,
+        to: G::LinkEndpoint,
+    ) -> String {
+        let from_offset = self.graph.port_offset(from).expect("missing port").index();
+        let to_node = self.graph.port_node(to).expect("missing node");
+        let to_offset = self.graph.port_offset(to).expect("missing port").index();
+        let edge_style = self.edge_style(from, to);
+        let edge_label = edge_style.as_str();
+        format!(
+            "{}:out{} -> {}:in{} [style=\"{edge_label}\"]\n",
+            from_node.index(),
+            from_offset,
+            to_node.index(),
+            to_offset,
+        )
+    }
 
-        let node_str = format!("{} [shape=plain label=<", node.index())
-            + "<table border=\"1\">"
-            + &inputs_row
-            + &label_row
-            + &outputs_row
-            + "</table>"
-            + ">]\n";
-        dot_str.push_str(&node_str);
+    fn hierarchy_strings(&mut self, dot: &mut String) {
+        if let Some(forest) = self.forest {
+            let hier_node_id = |n: NodeIndex| format!("hier{}", n.index());
 
-        // Connect the linked output ports
-        graph
-            .outputs(node)
-            .flat_map(|port| graph.port_links(port))
-            .map(|(from, to)| get_edge_dot(graph, node, from, to, &mut edges))
-            .for_each(|edge| {
-                dot_str.push_str(&edge);
-            });
+            for n in self.graph.nodes_iter() {
+                let node_str = format!(
+                    "{} [shape=plain label=\"{}\"]\n",
+                    hier_node_id(n),
+                    n.index()
+                );
+                dot.push_str(&node_str);
+
+                // Connect the parent to any existing children
+                forest.children(n).for_each(|child| {
+                    dot.push_str(&{
+                        let from_node = n;
+                        let to_node = child;
+                        format!(
+                            "{} -> {}  [style = \"dashed\"] \n",
+                            hier_node_id(from_node),
+                            hier_node_id(to_node),
+                        )
+                    });
+                });
+            }
+        }
     }
 }
 
-/// Outputs an html table row with the ports of a node.
-///
-/// `num_others` is the number of ports in the other direction.
-fn get_ports_row_dot<G: LinkView>(
-    graph: &G,
-    node: NodeIndex,
-    direction: Direction,
-    num_others: usize,
-    mut ports: impl FnMut(PortIndex) -> PortStyle,
-) -> String {
-    if graph.num_ports(node, direction) == 0 {
-        return String::new();
-    }
-    let dir = match direction {
-        Direction::Incoming => "in",
-        Direction::Outgoing => "out",
-    };
+/// A trait for encoding a graph in dot format.
+pub trait DotFormat: LinkView + Sized {
+    /// Initialize a `DotFormatter` for the graph.
+    fn dot_format(&self) -> DotFormatter<'_, Self>;
 
-    let separator = |label: &str| if label.is_empty() { "" } else { ": " };
-
-    let mut ports_row = "<tr>".to_string();
-    for (offset, port) in graph.ports(node, direction).enumerate() {
-        let port_str = match ports(port) {
-            PortStyle::Hidden =>
-                format!("<td port=\"{dir}{offset}\" align=\"text\" colspan=\"0\"></td>"),
-            PortStyle::Text(label) =>
-                format!("<td port=\"{dir}{offset}\" align=\"text\" colspan=\"{num_others}\">{offset}{label}</td>"),
-            PortStyle::Box(label) => format!(
-                    "<td port=\"{dir}{offset}\" align=\"text\" colspan=\"{num_others}\" cellpadding=\"1\">{offset}{separator}{label}</td>",
-                    separator = separator(&label),
-                ),
-        };
-        ports_row.push_str(&port_str);
+    /// Encode the graph in dot format.
+    fn dot_string(&self) -> String {
+        self.dot_format().finish()
     }
-    ports_row.push_str("</tr>");
-    ports_row
 }
 
-/// If the port is linked, outputs the edge in dot format.
-fn get_edge_dot<G: LinkView>(
-    graph: &G,
-    from_node: NodeIndex,
-    from: G::LinkEndpoint,
-    to: G::LinkEndpoint,
-    mut edges: impl FnMut(G::LinkEndpoint, G::LinkEndpoint) -> EdgeStyle,
-) -> String {
-    let from_offset = graph.port_offset(from).expect("missing port").index();
-    let to_node = graph.port_node(to).expect("missing node");
-    let to_offset = graph.port_offset(to).expect("missing port").index();
-    let edge_style = edges(from, to);
-    let edge_label = edge_style.as_str();
-    format!(
-        "{}:out{} -> {}:in{} [style=\"{edge_label}\"]\n",
-        from_node.index(),
-        from_offset,
-        to_node.index(),
-        to_offset,
-    )
+impl<G> DotFormat for G
+where
+    G: LinkView,
+{
+    fn dot_format(&self) -> DotFormatter<'_, Self> {
+        DotFormatter::new(self)
+    }
 }
 
 #[cfg(test)]
@@ -301,7 +341,7 @@ mod tests {
         graph.link_nodes(n1, 0, n2, 0).unwrap();
         graph.link_nodes(n1, 1, n3, 0).unwrap();
 
-        let dot = dot_string(&graph);
+        let dot = &graph.dot_string();
         let expected = r#"digraph {
 0 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="2" cellpadding="1">0</td><td port="in1" align="text" colspan="2" cellpadding="1">1</td><td port="in2" align="text" colspan="2" cellpadding="1">2</td></tr><tr><td align="text" border="0" colspan="6">0</td></tr><tr><td port="out0" align="text" colspan="3" cellpadding="1">0</td><td port="out1" align="text" colspan="3" cellpadding="1">1</td></tr></table>>]
 0:out0 -> 1:in0 [style=""]
@@ -310,7 +350,7 @@ mod tests {
 2 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="1" cellpadding="1">0</td></tr><tr><td align="text" border="0" colspan="1">2</td></tr></table>>]
 }
 "#;
-        assert_eq!(dot, expected);
+        assert_eq!(dot, expected, "\n{}\n{}\n", dot, expected);
     }
 
     #[test]
@@ -326,19 +366,13 @@ mod tests {
 
         hier.push_child(n2, n1).unwrap();
         hier.push_child(n3, n1).unwrap();
-        let dot = hier_graph_dot_string_with(
-            &graph,
-            &hier,
-            |_| Default::default(),
-            |_| Default::default(),
-            |_, _| Default::default(),
-        );
+        let dot = graph.dot_format().with_hierarchy(&hier).finish();
         let expected = r#"digraph {
-0 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="2" cellpadding="1">0</td><td port="in1" align="text" colspan="2" cellpadding="1">1</td><td port="in2" align="text" colspan="2" cellpadding="1">2</td></tr><tr><td align="text" border="0" colspan="6"></td></tr><tr><td port="out0" align="text" colspan="3" cellpadding="1">0</td><td port="out1" align="text" colspan="3" cellpadding="1">1</td></tr></table>>]
+0 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="2" cellpadding="1">0</td><td port="in1" align="text" colspan="2" cellpadding="1">1</td><td port="in2" align="text" colspan="2" cellpadding="1">2</td></tr><tr><td align="text" border="0" colspan="6">0</td></tr><tr><td port="out0" align="text" colspan="3" cellpadding="1">0</td><td port="out1" align="text" colspan="3" cellpadding="1">1</td></tr></table>>]
 0:out0 -> 1:in0 [style=""]
 0:out1 -> 2:in0 [style=""]
-1 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="1" cellpadding="1">0</td></tr><tr><td align="text" border="0" colspan="1"></td></tr></table>>]
-2 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="1" cellpadding="1">0</td></tr><tr><td align="text" border="0" colspan="1"></td></tr></table>>]
+1 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="1" cellpadding="1">0</td></tr><tr><td align="text" border="0" colspan="1">1</td></tr></table>>]
+2 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="1" cellpadding="1">0</td></tr><tr><td align="text" border="0" colspan="1">2</td></tr></table>>]
 hier0 [shape=plain label="0"]
 hier0 -> hier1  [style = "dashed"] 
 hier0 -> hier2  [style = "dashed"] 
@@ -346,7 +380,7 @@ hier1 [shape=plain label="1"]
 hier2 [shape=plain label="2"]
 }
 "#;
-        assert_eq!(dot, expected);
+        assert_eq!(dot, expected, "\n{}\n{}\n", dot, expected);
     }
 
     #[test]
@@ -372,7 +406,7 @@ hier2 [shape=plain label="2"]
         weights[p20] = "in 0".to_string();
         weights[p30] = "in 0".to_string();
 
-        let dot = dot_string_weighted(&graph, &weights);
+        let dot = graph.dot_format().with_weights(&weights).finish();
         println!("\n{}\n", dot);
         let expected = r#"digraph {
 0 [shape=plain label=<<table border="1"><tr><td align="text" border="0" colspan="2">node1</td></tr><tr><td port="out0" align="text" colspan="1" cellpadding="1">0: out 0</td><td port="out1" align="text" colspan="1" cellpadding="1">1: out 1</td></tr></table>>]
@@ -382,6 +416,6 @@ hier2 [shape=plain label="2"]
 2 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="1" cellpadding="1">0: in 0</td></tr><tr><td align="text" border="0" colspan="1">node3</td></tr></table>>]
 }
 "#;
-        assert_eq!(dot, expected);
+        assert_eq!(dot, expected, "\n{}\n{}\n", dot, expected);
     }
 }

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -2,28 +2,98 @@
 
 use std::fmt::Display;
 
-use crate::{Direction, Hierarchy, LinkView, NodeIndex, PortGraph, PortIndex, PortView, Weights};
+use crate::{Direction, Hierarchy, LinkView, NodeIndex, PortIndex, Weights};
 
 /// Style of an edge in a dot graph. Defaults to "None".
-pub type DotEdgeStyle = Option<String>;
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NodeStyle {
+    /// Ignore the node. No edges will be connected to it.
+    Hidden,
+    /// Draw a box with the label inside.
+    Box(String),
+}
 
-/// Encode `PortGraph` and `Hierarchy` in dot format.
+impl NodeStyle {
+    /// Box node with label inside.
+    pub fn new(label: impl ToString) -> Self {
+        Self::Box(label.to_string())
+    }
+}
+
+impl Default for NodeStyle {
+    fn default() -> Self {
+        Self::Box(String::new())
+    }
+}
+
+/// Style of an edge in a dot graph. Defaults to "None".
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PortStyle {
+    /// Do not draw a label. Edges will be connected to the node.
+    Hidden,
+    /// Just the port label
+    Text(String),
+    /// Draw a box around the label
+    Box(String),
+}
+
+impl PortStyle {
+    /// Custom style
+    pub fn new(style: impl ToString) -> Self {
+        Self::Box(style.to_string())
+    }
+}
+
+impl Default for PortStyle {
+    fn default() -> Self {
+        Self::Box(String::new())
+    }
+}
+
+/// Style of an edge in a dot graph. Defaults to "None".
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub enum EdgeStyle {
+    /// Normal line
+    #[default]
+    Solid,
+    /// Dotted line
+    Dotted,
+    /// Dashed line
+    Dashed,
+    /// Custom style
+    Custom(String),
+}
+
+impl EdgeStyle {
+    /// Get the style as a string
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Solid => "",
+            Self::Dotted => "dotted",
+            Self::Dashed => "dashed",
+            Self::Custom(s) => s,
+        }
+    }
+}
+
+/// Encode portgraph and `Hierarchy` in dot format.
 ///
 /// Calls the `nodes` and `ports` functions to get the labels for the nodes and ports.
 /// The `ports` function also returns the style of the edge connected to a port.
 ///
 /// Hierarchy relationships are shown as a separate tree of parent-child relationships
-pub fn hier_graph_dot_string_with(
-    graph: &PortGraph,
+pub fn hier_graph_dot_string_with<G: LinkView>(
+    graph: &G,
     forest: &Hierarchy,
-    nodes: impl FnMut(NodeIndex) -> String,
-    ports: impl FnMut(PortIndex) -> (String, DotEdgeStyle),
+    nodes: impl FnMut(NodeIndex) -> NodeStyle,
+    ports: impl FnMut(PortIndex) -> PortStyle,
+    edges: impl FnMut(G::LinkEndpoint, G::LinkEndpoint) -> EdgeStyle,
 ) -> String {
     let mut dot = String::new();
 
     dot.push_str("digraph {\n");
 
-    node_and_edge_strings(graph, &mut dot, nodes, ports);
+    node_and_edge_strings(graph, &mut dot, nodes, ports, edges);
 
     let hier_node_id = |n: NodeIndex| format!("hier{}", n.index());
 
@@ -53,77 +123,90 @@ pub fn hier_graph_dot_string_with(
     dot
 }
 
-/// Encode a `PortGraph` and `Hierarchy` in dot format.
-pub fn hier_graph_dot_string(graph: &PortGraph, hierarchy: &Hierarchy) -> String {
+/// Encode a portgraph and `Hierarchy` in dot format.
+pub fn hier_graph_dot_string(graph: &impl LinkView, hierarchy: &Hierarchy) -> String {
     hier_graph_dot_string_with(
         graph,
         hierarchy,
-        |n| n.index().to_string(),
-        |_| ("".to_string(), None),
+        |n| NodeStyle::new(n.index()),
+        |_| PortStyle::new(""),
+        |_, _| EdgeStyle::Solid,
     )
 }
 
-/// Encode a `PortGraph` in dot format.
-pub fn dot_string(graph: &PortGraph) -> String {
-    dot_string_with(graph, |n| n.index().to_string(), |_| ("".to_string(), None))
+/// Encode a portgraph in dot format.
+pub fn dot_string(graph: &impl LinkView) -> String {
+    dot_string_with(
+        graph,
+        |n| NodeStyle::new(n.index()),
+        |_| PortStyle::new(""),
+        |_, _| EdgeStyle::Solid,
+    )
 }
 
-/// Encode a `PortGraph` in dot format.
+/// Encode a portgraph in dot format.
 ///
 /// Uses the `weights` to label the nodes and ports.
-pub fn dot_string_weighted<N, P>(graph: &PortGraph, weights: &Weights<N, P>) -> String
+pub fn dot_string_weighted<N, P>(graph: &impl LinkView, weights: &Weights<N, P>) -> String
 where
     N: Display + Clone,
     P: Display + Clone,
 {
     dot_string_with(
         graph,
-        |n| weights.nodes[n].to_string(),
-        |p| (weights.ports[p].to_string(), None),
+        |n| NodeStyle::new(&weights.nodes[n]),
+        |p| PortStyle::new(&weights.ports[p]),
+        |_, _| EdgeStyle::Solid,
     )
 }
 
-/// Encode a `PortGraph` in dot format.
+/// Encode a portgraph in dot format.
 ///
 /// Calls the `nodes` and `ports` functions to get the labels for the nodes and ports.
 /// The `ports` function also returns the style of the edge connected to a port.
-pub fn dot_string_with(
-    graph: &PortGraph,
-    nodes: impl FnMut(NodeIndex) -> String,
-    ports: impl FnMut(PortIndex) -> (String, DotEdgeStyle),
+pub fn dot_string_with<G: LinkView>(
+    graph: &G,
+    nodes: impl FnMut(NodeIndex) -> NodeStyle,
+    ports: impl FnMut(PortIndex) -> PortStyle,
+    edges: impl FnMut(G::LinkEndpoint, G::LinkEndpoint) -> EdgeStyle,
 ) -> String {
     let mut dot = String::new();
 
     dot.push_str("digraph {\n");
-    node_and_edge_strings(graph, &mut dot, nodes, ports);
+    node_and_edge_strings(graph, &mut dot, nodes, ports, edges);
     dot.push_str("}\n");
     dot
 }
 
 /// Append the node and edge data in dot format to a string
-fn node_and_edge_strings(
-    graph: &PortGraph,
+fn node_and_edge_strings<G: LinkView>(
+    graph: &G,
     dot_str: &mut String,
-    mut nodes: impl FnMut(NodeIndex) -> String,
-    mut ports: impl FnMut(PortIndex) -> (String, DotEdgeStyle),
+    mut nodes: impl FnMut(NodeIndex) -> NodeStyle,
+    mut ports: impl FnMut(PortIndex) -> PortStyle,
+    mut edges: impl FnMut(G::LinkEndpoint, G::LinkEndpoint) -> EdgeStyle,
 ) {
-    for n in graph.nodes_iter() {
+    for node in graph.nodes_iter() {
         // Format the node as a table
+        let node_style = nodes(node);
+        let NodeStyle::Box(node_label) = node_style else {
+            // Ignore this node
+            continue;
+        };
 
         // Track the port counts for spacing
-        let ins = graph.num_inputs(n).max(1);
-        let outs = graph.num_outputs(n).max(1);
+        let ins = graph.num_inputs(node).max(1);
+        let outs = graph.num_outputs(node).max(1);
         let table_width = ins * outs;
 
-        let inputs_row = get_ports_row_dot(graph, n, Direction::Incoming, outs, &mut ports);
-        let outputs_row = get_ports_row_dot(graph, n, Direction::Outgoing, ins, &mut ports);
+        let inputs_row = get_ports_row_dot(graph, node, Direction::Incoming, outs, &mut ports);
+        let outputs_row = get_ports_row_dot(graph, node, Direction::Outgoing, ins, &mut ports);
 
-        let node_label = nodes(n);
         let label_row = format!(
             "<tr><td align=\"text\" border=\"0\" colspan=\"{table_width}\">{node_label}</td></tr>"
         );
 
-        let node_str = format!("{} [shape=plain label=<", n.index())
+        let node_str = format!("{} [shape=plain label=<", node.index())
             + "<table border=\"1\">"
             + &inputs_row
             + &label_row
@@ -134,9 +217,9 @@ fn node_and_edge_strings(
 
         // Connect the linked output ports
         graph
-            .outputs(n)
-            .enumerate()
-            .flat_map(|(offset, port)| get_edge_dot(graph, n, port, offset, &mut ports))
+            .outputs(node)
+            .flat_map(|port| graph.port_links(port))
+            .map(|(from, to)| get_edge_dot(graph, node, from, to, &mut edges))
             .for_each(|edge| {
                 dot_str.push_str(&edge);
             });
@@ -146,12 +229,12 @@ fn node_and_edge_strings(
 /// Outputs an html table row with the ports of a node.
 ///
 /// `num_others` is the number of ports in the other direction.
-fn get_ports_row_dot(
-    graph: &PortGraph,
+fn get_ports_row_dot<G: LinkView>(
+    graph: &G,
     node: NodeIndex,
     direction: Direction,
     num_others: usize,
-    mut ports: impl FnMut(PortIndex) -> (String, DotEdgeStyle),
+    mut ports: impl FnMut(PortIndex) -> PortStyle,
 ) -> String {
     if graph.num_ports(node, direction) == 0 {
         return String::new();
@@ -161,42 +244,51 @@ fn get_ports_row_dot(
         Direction::Outgoing => "out",
     };
 
+    let separator = |label: &str| if label.is_empty() { "" } else { ": " };
+
     let mut ports_row = "<tr>".to_string();
     for (offset, port) in graph.ports(node, direction).enumerate() {
-        let (port_label, _) = ports(port);
-        ports_row.push_str(&format!(
-            "<td port=\"{dir}{offset}\" align=\"text\" colspan=\"{num_others}\" cellpadding=\"1\">{offset}{separator}{port_label}</td>",
-            separator = if port_label.is_empty() { "" } else { ": " },
-        ));
+        let port_str = match ports(port) {
+            PortStyle::Hidden =>
+                format!("<td port=\"{dir}{offset}\" align=\"text\" colspan=\"0\"></td>"),
+            PortStyle::Text(label) =>
+                format!("<td port=\"{dir}{offset}\" align=\"text\" colspan=\"{num_others}\">{offset}{label}</td>"),
+            PortStyle::Box(label) => format!(
+                    "<td port=\"{dir}{offset}\" align=\"text\" colspan=\"{num_others}\" cellpadding=\"1\">{offset}{separator}{label}</td>",
+                    separator = separator(&label),
+                ),
+        };
+        ports_row.push_str(&port_str);
     }
     ports_row.push_str("</tr>");
     ports_row
 }
 
 /// If the port is linked, outputs the edge in dot format.
-fn get_edge_dot(
-    graph: &PortGraph,
+fn get_edge_dot<G: LinkView>(
+    graph: &G,
     from_node: NodeIndex,
-    from_port: PortIndex,
-    from_offset: usize,
-    mut ports: impl FnMut(PortIndex) -> (String, DotEdgeStyle),
-) -> Option<String> {
-    let to_port = graph.port_link(from_port)?;
-    let to_node = graph.port_node(to_port).expect("missing node");
-    let to_offset = graph.port_offset(to_port).expect("missing port").index();
-    let edge_style = ports(from_port).1.unwrap_or_default();
-    Some(format!(
-        "{}:out{} -> {}:in{} [style=\"{edge_style}\"]\n",
+    from: G::LinkEndpoint,
+    to: G::LinkEndpoint,
+    mut edges: impl FnMut(G::LinkEndpoint, G::LinkEndpoint) -> EdgeStyle,
+) -> String {
+    let from_offset = graph.port_offset(from).expect("missing port").index();
+    let to_node = graph.port_node(to).expect("missing node");
+    let to_offset = graph.port_offset(to).expect("missing port").index();
+    let edge_style = edges(from, to);
+    let edge_label = edge_style.as_str();
+    format!(
+        "{}:out{} -> {}:in{} [style=\"{edge_label}\"]\n",
         from_node.index(),
         from_offset,
         to_node.index(),
         to_offset,
-    ))
+    )
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{LinkView, PortView};
+    use crate::{PortGraph, PortView};
 
     use super::*;
 
@@ -239,6 +331,7 @@ mod tests {
             &hier,
             |_| Default::default(),
             |_| Default::default(),
+            |_, _| Default::default(),
         );
         let expected = r#"digraph {
 0 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="2" cellpadding="1">0</td><td port="in1" align="text" colspan="2" cellpadding="1">1</td><td port="in2" align="text" colspan="2" cellpadding="1">2</td></tr><tr><td align="text" border="0" colspan="6"></td></tr><tr><td port="out0" align="text" colspan="3" cellpadding="1">0</td><td port="out1" align="text" colspan="3" cellpadding="1">1</td></tr></table>>]

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -14,7 +14,7 @@ pub enum NodeStyle {
 }
 
 impl NodeStyle {
-    /// Box node with label inside.
+    /// Show a node label with the default style.
     pub fn new(label: impl ToString) -> Self {
         Self::Box(label.to_string())
     }
@@ -38,9 +38,9 @@ pub enum PortStyle {
 }
 
 impl PortStyle {
-    /// Custom style
-    pub fn new(style: impl ToString) -> Self {
-        Self::Box(style.to_string())
+    /// Show a port label with the default style.
+    pub fn new(label: impl ToString) -> Self {
+        Self::Box(label.to_string())
     }
 }
 
@@ -65,7 +65,7 @@ pub enum EdgeStyle {
 }
 
 impl EdgeStyle {
-    /// Get the style as a string
+    /// Get the style as a graphviz style string
     pub fn as_str(&self) -> &str {
         match self {
             Self::Solid => "",

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -26,7 +26,7 @@ impl Default for NodeStyle {
     }
 }
 
-/// Style of an edge in a dot graph. Defaults to "None".
+/// Style of an edge in a dot graph. Defaults to `Box("")`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PortStyle {
     /// Do not draw a label. Edges will be connected to the node.
@@ -50,7 +50,7 @@ impl Default for PortStyle {
     }
 }
 
-/// Style of an edge in a dot graph. Defaults to "None".
+/// Style of an edge in a dot graph. Defaults to [`EdgeStyle::Solid`].
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub enum EdgeStyle {
     /// Normal line


### PR DESCRIPTION
- Supports any `LinkView` graph, so MultiPortGraphs automatically hide the copy nodes.
- Refactors the combinatorial explosion of entry points (`dot_string`, `dot_string_with_hierarchy`, `dot_string_with_hierarchy_and_callbacks_and_...`) with a `DotFormatter` struct, so we can now do
```rust
graph.dot_format()
  .with_hierarchy(&hier)
  .with_node_style(|n| some_style(n))
  .finish();
```
- Adds explicit `{Node,Port,Edge}Style` enums to better control the options

The formatting result is left unchanged. (Except for a small difference in the old `hier_graph_dot_string_with`, which didn't show the node ids)