### PR TITLE
Split mutable methods from view traits 

### DIFF
--- a/benches/benchmarks/generators.rs
+++ b/benches/benchmarks/generators.rs
@@ -1,4 +1,4 @@
-use portgraph::{Hierarchy, LinkView, NodeIndex, PortGraph, PortView, Weights};
+use portgraph::{Hierarchy, LinkMut, NodeIndex, PortGraph, PortMut, PortView, Weights};
 
 /// Create line graph, connected with two parallel edges at each step.
 ///

--- a/benches/benchmarks/portgraph.rs
+++ b/benches/benchmarks/portgraph.rs
@@ -5,7 +5,7 @@ use super::generators::*;
 use criterion::{
     black_box, criterion_group, AxisScale, BatchSize, BenchmarkId, Criterion, PlotConfiguration,
 };
-use portgraph::{PortGraph, PortView};
+use portgraph::{PortGraph, PortMut, PortView};
 
 /// Remove one every five nodes from the graph.
 fn remove_every_five(graph: &mut PortGraph) {

--- a/benches/benchmarks/substitute.rs
+++ b/benches/benchmarks/substitute.rs
@@ -3,7 +3,7 @@
 use criterion::{black_box, criterion_group, BatchSize, Criterion};
 use portgraph::{
     substitute::{BoundedSubgraph, OpenGraph, Rewrite, WeightedRewrite},
-    LinkView, NodeIndex, PortGraph, PortView,
+    LinkView, NodeIndex, PortGraph, PortMut, PortView,
 };
 
 use super::generators::*;

--- a/src/algorithms/dominators.rs
+++ b/src/algorithms/dominators.rs
@@ -17,7 +17,8 @@ use std::cmp::Ordering;
 ///    ┗> d ┛
 ///
 /// ```
-/// # use portgraph::{algorithms::{dominators, DominatorTree}, Direction, PortGraph, PortView, LinkView};
+/// # use ::portgraph::algorithms::*;
+/// # use ::portgraph::*;
 /// let mut graph = PortGraph::with_capacity(5, 10);
 /// let a = graph.add_node(0,2);
 /// let b = graph.add_node(1,1);
@@ -67,7 +68,8 @@ where
 /// a ─┬> b ┐ │    ├─> c ─> e f ─┴> d ┴────────^
 ///
 /// ```
-/// # use portgraph::{algorithms::{dominators_filtered, DominatorTree}, Direction, PortGraph, PortView, LinkView};
+/// # use ::portgraph::algorithms::*;
+/// # use ::portgraph::*;
 /// let mut graph = PortGraph::with_capacity(5, 10);
 /// let a = graph.add_node(0,2);
 /// let b = graph.add_node(1,1);
@@ -233,6 +235,8 @@ fn intersect(dominators: &[usize], mut finger1: usize, mut finger2: usize) -> us
 
 #[cfg(test)]
 mod tests {
+    use crate::{LinkMut, PortMut};
+
     use super::*;
 
     #[test]

--- a/src/algorithms/post_order.rs
+++ b/src/algorithms/post_order.rs
@@ -22,7 +22,8 @@ use crate::{Direction, LinkView, NodeIndex, PortGraph, PortIndex, PortView};
 /// And traverse it in post-order:
 ///
 /// ```
-/// # use portgraph::{algorithms::postorder, Direction, PortGraph, PortView, LinkView};
+/// # use ::portgraph::algorithms::*;
+/// # use ::portgraph::*;
 /// let mut graph = PortGraph::new();
 ///
 /// let a = graph.add_node(0, 1);
@@ -78,7 +79,8 @@ pub fn postorder(
 /// And traverse it in post-order:
 ///
 /// ```
-/// # use portgraph::{algorithms::postorder_filtered, Direction, PortGraph, PortView, LinkView};
+/// # use ::portgraph::algorithms::*;
+/// # use ::portgraph::*;
 /// let mut graph = PortGraph::new();
 ///
 /// let a = graph.add_node(0, 1);
@@ -267,6 +269,8 @@ impl<'graph> std::fmt::Debug for PostOrder<'graph> {
 
 #[cfg(test)]
 mod tests {
+    use crate::{LinkMut, PortMut};
+
     use super::*;
 
     #[test]

--- a/src/algorithms/toposort.rs
+++ b/src/algorithms/toposort.rs
@@ -15,7 +15,8 @@ use std::{collections::VecDeque, fmt::Debug, iter::FusedIterator};
 /// # Example
 ///
 /// ```
-/// # use portgraph::{algorithms::{toposort, TopoSort}, Direction, PortGraph, PortView, LinkView};
+/// # use ::portgraph::algorithms::*;
+/// # use ::portgraph::*;
 /// let mut graph = PortGraph::new();
 /// let node_a = graph.add_node(2, 2);
 /// let node_b = graph.add_node(2, 2);
@@ -54,8 +55,8 @@ where
 /// # Example
 ///
 /// ```
-/// # use portgraph::{Direction, PortGraph, PortView, LinkView};
-/// # use portgraph::algorithms::{toposort, toposort_filtered, TopoSort};
+/// # use ::portgraph::algorithms::*;
+/// # use ::portgraph::*;
 /// let mut graph = PortGraph::new();
 /// let node_a = graph.add_node(2, 2);
 /// let node_b = graph.add_node(2, 2);
@@ -274,7 +275,7 @@ where
 mod test {
     use super::*;
 
-    use crate::{Direction, PortGraph};
+    use crate::{Direction, LinkMut, PortMut, PortView};
 
     #[test]
     fn small_toposort() {

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -384,7 +384,7 @@ struct PortCellStrings {
 
 #[cfg(test)]
 mod tests {
-    use crate::{PortGraph, PortView};
+    use crate::{LinkMut, PortGraph, PortMut, PortView};
 
     use super::*;
 

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -13,8 +13,7 @@
 //! # Example
 //!
 //! ```
-//! # use portgraph::{PortGraph, NodeIndex, PortIndex, PortView, LinkView};
-//! # use portgraph::hierarchy::Hierarchy;
+//! # use ::portgraph::*;
 //! let mut graph = PortGraph::new();
 //! let mut hierarchy = Hierarchy::new();
 //!
@@ -555,7 +554,7 @@ pub enum AttachError {
 
 #[cfg(test)]
 mod test {
-    use crate::{PortGraph, PortView};
+    use crate::{PortGraph, PortMut, PortView};
 
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,8 @@
 //! # Example
 //!
 //! ```
-//! use portgraph::{PortGraph, Direction, PortView, LinkView};
-//! use portgraph::algorithms::{toposort, TopoSort};
+//! use ::portgraph::*;
+//! use ::portgraph::algorithms::{toposort, TopoSort};
 //!
 //! // Create a graph with two nodes, each with two input and two output ports
 //! let mut graph = PortGraph::new();
@@ -82,13 +82,15 @@ pub mod proptest;
 #[doc(inline)]
 pub use crate::hierarchy::Hierarchy;
 #[doc(inline)]
+pub use crate::multiportgraph::MultiPortGraph;
+#[doc(inline)]
 pub use crate::portgraph::{LinkError, PortGraph};
 #[doc(inline)]
 pub use crate::secondary::SecondaryMap;
 #[doc(inline)]
 pub use crate::unmanaged::UnmanagedDenseMap;
 #[doc(inline)]
-pub use crate::view::{LinkView, MultiView, PortView};
+pub use crate::view::{LinkMut, LinkView, MultiMut, MultiView, PortMut, PortView};
 #[doc(inline)]
 pub use crate::weights::Weights;
 

--- a/src/multiportgraph.rs
+++ b/src/multiportgraph.rs
@@ -390,13 +390,11 @@ impl LinkMut for MultiPortGraph {
 }
 
 impl MultiView for MultiPortGraph {
-    type SubportIndex = SubportIndex;
-
     type NodeSubports<'a> = NodeSubports<'a>
     where
         Self: 'a;
 
-    fn subport_link(&self, subport: Self::SubportIndex) -> Option<Self::SubportIndex> {
+    fn subport_link(&self, subport: SubportIndex) -> Option<SubportIndex> {
         let subport_index = self.get_subport_index(subport)?;
         let link = self.graph.port_link(subport_index)?;
         self.get_subport_from_index(link)
@@ -416,8 +414,8 @@ impl MultiView for MultiPortGraph {
 impl MultiMut for MultiPortGraph {
     fn link_subports(
         &mut self,
-        subport_from: Self::SubportIndex,
-        subport_to: Self::SubportIndex,
+        subport_from: SubportIndex,
+        subport_to: SubportIndex,
     ) -> Result<(), LinkError> {
         // TODO: Custom errors
         let from_index = self
@@ -430,7 +428,7 @@ impl MultiMut for MultiPortGraph {
         Ok(())
     }
 
-    fn unlink_subport(&mut self, subport: Self::SubportIndex) -> Option<Self::SubportIndex> {
+    fn unlink_subport(&mut self, subport: SubportIndex) -> Option<SubportIndex> {
         // TODO: Remove copy nodes when they are no longer needed?
         let subport_index = self.get_subport_index(subport)?;
         let link = self.graph.unlink_port(subport_index)?;

--- a/src/multiportgraph.rs
+++ b/src/multiportgraph.rs
@@ -6,7 +6,7 @@ pub use self::iter::{
     Neighbours, NodeConnections, NodeLinks, NodeSubports, Nodes, PortLinks, Ports,
 };
 use crate::portgraph::{NodePortOffsets, NodePorts, PortOperation};
-use crate::view::MultiView;
+use crate::view::{LinkMut, MultiMut, MultiView, PortMut};
 use crate::{
     Direction, LinkError, LinkView, NodeIndex, PortGraph, PortIndex, PortOffset, PortView,
     SecondaryMap,
@@ -114,21 +114,6 @@ impl PortView for MultiPortGraph {
         Self: 'a;
 
     #[inline]
-    fn add_node(&mut self, incoming: usize, outgoing: usize) -> NodeIndex {
-        self.graph.add_node(incoming, outgoing)
-    }
-
-    fn remove_node(&mut self, node: NodeIndex) {
-        debug_assert!(!self.copy_node.get(node));
-        for port in self.graph.all_ports(node) {
-            if *self.multiport.get(port) {
-                self.unlink_port(port);
-            }
-        }
-        self.graph.remove_node(node);
-    }
-
-    #[inline]
     fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction> {
         self.graph.port_direction(port.into())
     }
@@ -226,14 +211,6 @@ impl PortView for MultiPortGraph {
         Ports::new(self, self.graph.ports_iter())
     }
 
-    fn clear(&mut self) {
-        self.graph.clear();
-        self.multiport.clear();
-        self.copy_node.clear();
-        self.copy_node_count = 0;
-        self.subport_count = 0;
-    }
-
     #[inline]
     fn node_capacity(&self) -> usize {
         self.graph.node_capacity() - self.copy_node_count
@@ -248,6 +225,31 @@ impl PortView for MultiPortGraph {
     #[inline]
     fn node_port_capacity(&self, node: NodeIndex) -> usize {
         self.graph.node_port_capacity(node)
+    }
+}
+
+impl PortMut for MultiPortGraph {
+    #[inline]
+    fn add_node(&mut self, incoming: usize, outgoing: usize) -> NodeIndex {
+        self.graph.add_node(incoming, outgoing)
+    }
+
+    fn remove_node(&mut self, node: NodeIndex) {
+        debug_assert!(!self.copy_node.get(node));
+        for port in self.graph.all_ports(node) {
+            if *self.multiport.get(port) {
+                self.unlink_port(port);
+            }
+        }
+        self.graph.remove_node(node);
+    }
+
+    fn clear(&mut self) {
+        self.graph.clear();
+        self.multiport.clear();
+        self.copy_node.clear();
+        self.copy_node_count = 0;
+        self.subport_count = 0;
     }
 
     #[inline]
@@ -325,29 +327,6 @@ impl LinkView for MultiPortGraph {
     where
         Self: 'a;
 
-    fn link_ports(
-        &mut self,
-        port_a: PortIndex,
-        port_b: PortIndex,
-    ) -> Result<(SubportIndex, SubportIndex), LinkError> {
-        let (multiport_a, index_a) = self.get_free_multiport(port_a)?;
-        let (multiport_b, index_b) = self.get_free_multiport(port_b)?;
-        self.graph.link_ports(index_a, index_b)?;
-        Ok((multiport_a, multiport_b))
-    }
-
-    fn unlink_port(&mut self, port: PortIndex) -> Option<SubportIndex> {
-        if self.is_multiport(port) {
-            let link = self
-                .graph
-                .port_link(port)
-                .expect("MultiPortGraph error: a port marked as multiport has no link.");
-            self.remove_copy_node(port, link)
-        } else {
-            self.graph.unlink_port(port).map(SubportIndex::new_unique)
-        }
-    }
-
     #[inline]
     fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> Self::NodeConnections<'_> {
         NodeConnections::new(self, to, self.output_links(from))
@@ -385,6 +364,31 @@ impl LinkView for MultiPortGraph {
     }
 }
 
+impl LinkMut for MultiPortGraph {
+    fn link_ports(
+        &mut self,
+        port_a: PortIndex,
+        port_b: PortIndex,
+    ) -> Result<(SubportIndex, SubportIndex), LinkError> {
+        let (multiport_a, index_a) = self.get_free_multiport(port_a)?;
+        let (multiport_b, index_b) = self.get_free_multiport(port_b)?;
+        self.graph.link_ports(index_a, index_b)?;
+        Ok((multiport_a, multiport_b))
+    }
+
+    fn unlink_port(&mut self, port: PortIndex) -> Option<SubportIndex> {
+        if self.is_multiport(port) {
+            let link = self
+                .graph
+                .port_link(port)
+                .expect("MultiPortGraph error: a port marked as multiport has no link.");
+            self.remove_copy_node(port, link)
+        } else {
+            self.graph.unlink_port(port).map(SubportIndex::new_unique)
+        }
+    }
+}
+
 impl MultiView for MultiPortGraph {
     type SubportIndex = SubportIndex;
 
@@ -392,6 +396,24 @@ impl MultiView for MultiPortGraph {
     where
         Self: 'a;
 
+    fn subport_link(&self, subport: Self::SubportIndex) -> Option<Self::SubportIndex> {
+        let subport_index = self.get_subport_index(subport)?;
+        let link = self.graph.port_link(subport_index)?;
+        self.get_subport_from_index(link)
+    }
+
+    #[inline]
+    fn subports(&self, node: NodeIndex, direction: Direction) -> Self::NodeSubports<'_> {
+        NodeSubports::new(self, self.graph.ports(node, direction))
+    }
+
+    #[inline]
+    fn all_subports(&self, node: NodeIndex) -> Self::NodeSubports<'_> {
+        NodeSubports::new(self, self.graph.all_ports(node))
+    }
+}
+
+impl MultiMut for MultiPortGraph {
     fn link_subports(
         &mut self,
         subport_from: Self::SubportIndex,
@@ -413,22 +435,6 @@ impl MultiView for MultiPortGraph {
         let subport_index = self.get_subport_index(subport)?;
         let link = self.graph.unlink_port(subport_index)?;
         self.get_subport_from_index(link)
-    }
-
-    fn subport_link(&self, subport: Self::SubportIndex) -> Option<Self::SubportIndex> {
-        let subport_index = self.get_subport_index(subport)?;
-        let link = self.graph.port_link(subport_index)?;
-        self.get_subport_from_index(link)
-    }
-
-    #[inline]
-    fn subports(&self, node: NodeIndex, direction: Direction) -> Self::NodeSubports<'_> {
-        NodeSubports::new(self, self.graph.ports(node, direction))
-    }
-
-    #[inline]
-    fn all_subports(&self, node: NodeIndex) -> Self::NodeSubports<'_> {
-        NodeSubports::new(self, self.graph.all_ports(node))
     }
 }
 

--- a/src/proptest.rs
+++ b/src/proptest.rs
@@ -4,7 +4,7 @@
 //! returns strategies that generate random portgraphs.
 use std::iter::zip;
 
-use crate::{Direction, LinkView, NodeIndex, PortGraph, PortIndex, PortView};
+use crate::{Direction, LinkMut, NodeIndex, PortGraph, PortIndex, PortMut, PortView};
 use proptest::prelude::*;
 use rand::seq::SliceRandom;
 
@@ -100,6 +100,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::LinkView;
 
     proptest! {
         #[test]

--- a/src/substitute.rs
+++ b/src/substitute.rs
@@ -7,6 +7,7 @@
 //! matching the replaced subgraph hierarchy in the replacement.
 
 use crate::portgraph::LinkError;
+use crate::view::{LinkMut, PortMut};
 use crate::weights::Weights;
 use crate::{LinkView, NodeIndex, PortGraph, PortIndex, PortView};
 
@@ -388,8 +389,7 @@ mod tests {
     use std::collections::HashSet;
     use std::error::Error;
 
-    use crate::substitute::{BoundedSubgraph, OpenGraph, Rewrite, WeightedRewrite};
-    use crate::{LinkView, PortGraph, PortView, Weights};
+    use super::*;
 
     #[test]
     fn test_remove_subgraph() -> Result<(), Box<dyn Error>> {

--- a/src/unmanaged.rs
+++ b/src/unmanaged.rs
@@ -15,8 +15,7 @@
 //! # Example
 //!
 //! ```
-//! # use portgraph::{PortGraph, NodeIndex, PortIndex, PortView, LinkView};
-//! # use portgraph::unmanaged::UnmanagedDenseMap;
+//! # use ::portgraph::*;
 //!
 //! let mut graph = PortGraph::new();
 //! let mut node_weights = UnmanagedDenseMap::<NodeIndex, usize>::new();

--- a/src/view.rs
+++ b/src/view.rs
@@ -543,18 +543,15 @@ pub trait LinkMut: LinkView + PortMut {
 
 /// Abstraction over a portgraph that may have multiple connections per node.
 pub trait MultiView: LinkView {
-    /// An index type used to identify specific connections in a multiport.
-    type SubportIndex;
-
     /// Iterator over all the subports of a node.
-    type NodeSubports<'a>: Iterator<Item = Self::SubportIndex>
+    type NodeSubports<'a>: Iterator<Item = Self::LinkEndpoint>
     where
         Self: 'a;
 
     /// Return the subport linked to the given `port`. If the port is not
     /// connected, return None.
     #[must_use]
-    fn subport_link(&self, subport: Self::SubportIndex) -> Option<Self::SubportIndex>;
+    fn subport_link(&self, subport: Self::LinkEndpoint) -> Option<Self::LinkEndpoint>;
 
     /// Iterates over all the subports of the `node` in the given `direction`.
     #[must_use]
@@ -594,11 +591,11 @@ pub trait MultiMut: MultiView + LinkMut {
     ///  - If `subport_from` or `subport_to` is already linked.
     fn link_subports(
         &mut self,
-        subport_from: Self::SubportIndex,
-        subport_to: Self::SubportIndex,
+        subport_from: Self::LinkEndpoint,
+        subport_to: Self::LinkEndpoint,
     ) -> Result<(), LinkError>;
 
     /// Unlinks the `port` and returns the subport it was linked to. Returns `None`
     /// when the port was not linked.
-    fn unlink_subport(&mut self, subport: Self::SubportIndex) -> Option<Self::SubportIndex>;
+    fn unlink_subport(&mut self, subport: Self::LinkEndpoint) -> Option<Self::LinkEndpoint>;
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -5,7 +5,7 @@ pub mod petgraph;
 
 use crate::{portgraph::PortOperation, Direction, LinkError, NodeIndex, PortIndex, PortOffset};
 
-/// Core capabilities of a graph containing nodes and ports.
+/// Core capabilities for querying a graph containing nodes and ports.
 pub trait PortView {
     /// Iterator over the nodes of the graph.
     type Nodes<'a>: Iterator<Item = NodeIndex>
@@ -26,45 +26,6 @@ pub trait PortView {
     type NodePortOffsets<'a>: Iterator<Item = PortOffset>
     where
         Self: 'a;
-
-    /// Adds a node to the portgraph with a given number of input and output ports.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the total number of ports exceeds `u16::MAX`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use portgraph::{Direction, PortView, LinkView, MultiView};
-    /// # use portgraph::PortGraph;
-    /// let mut g = PortGraph::new();
-    /// let node = g.add_node(4, 3);
-    /// assert_eq!(g.inputs(node).count(), 4);
-    /// assert_eq!(g.outputs(node).count(), 3);
-    /// assert!(g.contains_node(node));
-    /// ```
-    fn add_node(&mut self, incoming: usize, outgoing: usize) -> NodeIndex;
-
-    /// Remove a node from the port graph. All ports of the node will be
-    /// unlinked and removed as well. Does nothing if the node does not exist.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use portgraph::{Direction, PortView, LinkView, MultiView};
-    /// # use portgraph::PortGraph;
-    /// let mut g = PortGraph::new();
-    /// let node0 = g.add_node(1, 1);
-    /// let node1 = g.add_node(1, 1);
-    /// g.link_ports(g.outputs(node0).nth(0).unwrap(), g.inputs(node1).nth(0).unwrap());
-    /// g.link_ports(g.outputs(node1).nth(0).unwrap(), g.inputs(node0).nth(0).unwrap());
-    /// g.remove_node(node0);
-    /// assert!(!g.contains_node(node0));
-    /// assert!(g.port_link(g.outputs(node1).nth(0).unwrap()).is_none());
-    /// assert!(g.port_link(g.inputs(node1).nth(0).unwrap()).is_none());
-    /// ```
-    fn remove_node(&mut self, node: NodeIndex);
 
     /// Returns the direction of the `port`.
     #[must_use]
@@ -147,8 +108,7 @@ pub trait PortView {
     /// # Example
     ///
     /// ```
-    /// # use portgraph::PortGraph;
-    /// # use portgraph::{Direction, PortOffset, PortView, LinkView};
+    /// # use ::portgraph::*;
     /// let mut graph = PortGraph::new();
     /// let node = graph.add_node(0, 2);
     ///
@@ -208,9 +168,6 @@ pub trait PortView {
     #[must_use]
     fn ports_iter(&self) -> Self::Ports<'_>;
 
-    /// Removes all nodes and ports from the port graph.
-    fn clear(&mut self);
-
     /// Returns the capacity of the underlying buffer for nodes.
     #[must_use]
     fn node_capacity(&self) -> usize;
@@ -225,6 +182,49 @@ pub trait PortView {
     /// until the number of ports exceeds this capacity.
     #[must_use]
     fn node_port_capacity(&self, node: NodeIndex) -> usize;
+}
+
+/// Core capabilities for mutating a graph containing nodes and ports.
+pub trait PortMut: PortView {
+    /// Adds a node to the portgraph with a given number of input and output ports.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the total number of ports exceeds `u16::MAX`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use ::portgraph::*;
+    /// let mut g = PortGraph::new();
+    /// let node = g.add_node(4, 3);
+    /// assert_eq!(g.inputs(node).count(), 4);
+    /// assert_eq!(g.outputs(node).count(), 3);
+    /// assert!(g.contains_node(node));
+    /// ```
+    fn add_node(&mut self, incoming: usize, outgoing: usize) -> NodeIndex;
+
+    /// Remove a node from the port graph. All ports of the node will be
+    /// unlinked and removed as well. Does nothing if the node does not exist.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use ::portgraph::*;
+    /// let mut g = PortGraph::new();
+    /// let node0 = g.add_node(1, 1);
+    /// let node1 = g.add_node(1, 1);
+    /// g.link_ports(g.outputs(node0).nth(0).unwrap(), g.inputs(node1).nth(0).unwrap());
+    /// g.link_ports(g.outputs(node1).nth(0).unwrap(), g.inputs(node0).nth(0).unwrap());
+    /// g.remove_node(node0);
+    /// assert!(!g.contains_node(node0));
+    /// assert!(g.port_link(g.outputs(node1).nth(0).unwrap()).is_none());
+    /// assert!(g.port_link(g.inputs(node1).nth(0).unwrap()).is_none());
+    /// ```
+    fn remove_node(&mut self, node: NodeIndex);
+
+    /// Removes all nodes and ports from the port graph.
+    fn clear(&mut self);
 
     /// Reserves enough capacity to insert at least the given number of additional nodes and ports.
     ///
@@ -295,13 +295,179 @@ pub trait LinkView: PortView {
     where
         Self: 'a;
 
+    /// Returns an iterator over every pair of matching ports connecting `from`
+    /// with `to`.
+    ///
+    /// # Example
+    /// ```
+    /// # use ::portgraph::*;
+    /// let mut g = PortGraph::new();
+    /// let a = g.add_node(0, 2);
+    /// let b = g.add_node(2, 0);
+    ///
+    /// g.link_nodes(a, 0, b, 0).unwrap();
+    /// g.link_nodes(a, 1, b, 1).unwrap();
+    ///
+    /// let mut connections = g.get_connections(a, b);
+    /// assert_eq!(connections.next(), Some((g.output(a,0).unwrap(), g.input(b,0).unwrap())));
+    /// assert_eq!(connections.next(), Some((g.output(a,1).unwrap(), g.input(b,1).unwrap())));
+    /// assert_eq!(connections.next(), None);
+    /// ```
+    #[must_use]
+    fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> Self::NodeConnections<'_>;
+
+    /// Checks whether there is a directed link between the two nodes and
+    /// returns the first matching pair of ports.
+    ///
+    /// # Example
+    /// ```
+    /// # use ::portgraph::*;
+    /// let mut g = PortGraph::new();
+    /// let a = g.add_node(0, 2);
+    /// let b = g.add_node(2, 0);
+    ///
+    /// g.link_nodes(a, 0, b, 0).unwrap();
+    /// g.link_nodes(a, 1, b, 1).unwrap();
+    ///
+    /// assert_eq!(g.get_connection(a, b), Some((g.output(a,0).unwrap(), g.input(b,0).unwrap())));
+    /// ```
+    #[must_use]
+    fn get_connection(
+        &self,
+        from: NodeIndex,
+        to: NodeIndex,
+    ) -> Option<(Self::LinkEndpoint, Self::LinkEndpoint)> {
+        self.get_connections(from, to).next()
+    }
+
+    /// Checks whether there is a directed link between the two nodes.
+    ///
+    /// # Example
+    /// ```
+    /// # use ::portgraph::*;
+    /// let mut g = PortGraph::new();
+    /// let a = g.add_node(0, 2);
+    /// let b = g.add_node(2, 0);
+    ///
+    /// g.link_nodes(a, 0, b, 0).unwrap();
+    ///
+    /// assert!(g.connected(a, b));
+    /// ```
+    #[must_use]
+    #[inline]
+    fn connected(&self, from: NodeIndex, to: NodeIndex) -> bool {
+        self.get_connection(from, to).is_some()
+    }
+
+    /// Returns the port that the given `port` is linked to.
+    #[must_use]
+    fn port_links(&self, port: PortIndex) -> Self::PortLinks<'_>;
+
+    /// Return the link to the provided port, if not connected return None.
+    /// If this port has multiple connected subports, an arbitrary one is returned.
+    #[must_use]
+    #[inline]
+    fn port_link(&self, port: PortIndex) -> Option<Self::LinkEndpoint> {
+        self.port_links(port).next().map(|(_, p)| p)
+    }
+
+    /// Iterates over the connected links of the `node` in the given
+    /// `direction`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ::portgraph::*;
+    ///
+    /// let mut graph = PortGraph::new();
+    ///
+    /// let node_a = graph.add_node(0, 2);
+    /// let node_b = graph.add_node(1, 0);
+    ///
+    /// let port_a = graph.outputs(node_a).next().unwrap();
+    /// let port_b = graph.inputs(node_b).next().unwrap();
+    ///
+    /// graph.link_ports(port_a, port_b).unwrap();
+    ///
+    /// assert!(graph.links(node_a, Direction::Outgoing).eq([(port_a, port_b)]));
+    /// assert!(graph.links(node_b, Direction::Incoming).eq([(port_b, port_a)]));
+    /// ```
+    #[must_use]
+    fn links(&self, node: NodeIndex, direction: Direction) -> Self::NodeLinks<'_>;
+
+    /// Iterates over the connected input and output links of the `node` in sequence.
+    #[must_use]
+    fn all_links(&self, node: NodeIndex) -> Self::NodeLinks<'_>;
+
+    /// Iterates over the connected input links of the `node`. Shorthand for
+    /// [`LinkView::links`].
+    #[must_use]
+    #[inline]
+    fn input_links(&self, node: NodeIndex) -> Self::NodeLinks<'_> {
+        self.links(node, Direction::Incoming)
+    }
+
+    /// Iterates over the connected output links of the `node`. Shorthand for
+    /// [`LinkView::links`].
+    #[must_use]
+    #[inline]
+    fn output_links(&self, node: NodeIndex) -> Self::NodeLinks<'_> {
+        self.links(node, Direction::Outgoing)
+    }
+
+    /// Iterates over neighbour nodes in the given `direction`.
+    /// May contain duplicates if the graph has multiple links between nodes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ::portgraph::*;
+    ///
+    /// let mut graph = PortGraph::new();
+    ///
+    /// let a = graph.add_node(0, 1);
+    /// let b = graph.add_node(2, 1);
+    ///
+    /// graph.link_nodes(a, 0, b, 0).unwrap();
+    /// graph.link_nodes(b, 0, b, 1).unwrap();
+    ///
+    /// assert!(graph.neighbours(a, Direction::Outgoing).eq([b]));
+    /// assert!(graph.neighbours(b, Direction::Incoming).eq([a,b]));
+    /// ```
+    #[must_use]
+    fn neighbours(&self, node: NodeIndex, direction: Direction) -> Self::Neighbours<'_>;
+
+    /// Iterates over the input and output neighbours of the `node` in sequence.
+    #[must_use]
+    fn all_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_>;
+
+    /// Iterates over the input neighbours of the `node`. Shorthand for [`LinkView::neighbours`].
+    #[must_use]
+    #[inline]
+    fn input_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_> {
+        self.neighbours(node, Direction::Incoming)
+    }
+
+    /// Iterates over the output neighbours of the `node`. Shorthand for [`LinkView::neighbours`].
+    #[must_use]
+    #[inline]
+    fn output_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_> {
+        self.neighbours(node, Direction::Outgoing)
+    }
+
+    /// Returns the number of links between ports.
+    #[must_use]
+    fn link_count(&self) -> usize;
+}
+
+/// Mutating operations pertaining the adjacency of nodes in a port graph.
+pub trait LinkMut: LinkView + PortMut {
     /// Link an output port to an input port.
     ///
     /// # Example
     ///
     /// ```
-    /// # use portgraph::PortGraph;
-    /// # use portgraph::{Direction, PortView, LinkView, MultiView};
+    /// # use ::portgraph::*;
     /// let mut g = PortGraph::new();
     /// let node0 = g.add_node(0, 1);
     /// let node1 = g.add_node(1, 0);
@@ -373,172 +539,6 @@ pub trait LinkView: PortView {
     /// Unlinks all connections to the `port`. If the port was connected,
     /// returns one of the ports it was connected to.
     fn unlink_port(&mut self, port: PortIndex) -> Option<Self::LinkEndpoint>;
-
-    /// Returns an iterator over every pair of matching ports connecting `from`
-    /// with `to`.
-    ///
-    /// # Example
-    /// ```
-    /// # use portgraph::{PortGraph, NodeIndex, PortIndex, Direction, PortView, LinkView};
-    /// let mut g = PortGraph::new();
-    /// let a = g.add_node(0, 2);
-    /// let b = g.add_node(2, 0);
-    ///
-    /// g.link_nodes(a, 0, b, 0).unwrap();
-    /// g.link_nodes(a, 1, b, 1).unwrap();
-    ///
-    /// let mut connections = g.get_connections(a, b);
-    /// assert_eq!(connections.next(), Some((g.output(a,0).unwrap(), g.input(b,0).unwrap())));
-    /// assert_eq!(connections.next(), Some((g.output(a,1).unwrap(), g.input(b,1).unwrap())));
-    /// assert_eq!(connections.next(), None);
-    /// ```
-    #[must_use]
-    fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> Self::NodeConnections<'_>;
-
-    /// Checks whether there is a directed link between the two nodes and
-    /// returns the first matching pair of ports.
-    ///
-    /// # Example
-    /// ```
-    /// # use portgraph::{NodeIndex, PortIndex, Direction, PortView, LinkView, PortGraph};
-    /// let mut g = PortGraph::new();
-    /// let a = g.add_node(0, 2);
-    /// let b = g.add_node(2, 0);
-    ///
-    /// g.link_nodes(a, 0, b, 0).unwrap();
-    /// g.link_nodes(a, 1, b, 1).unwrap();
-    ///
-    /// assert_eq!(g.get_connection(a, b), Some((g.output(a,0).unwrap(), g.input(b,0).unwrap())));
-    /// ```
-    #[must_use]
-    fn get_connection(
-        &self,
-        from: NodeIndex,
-        to: NodeIndex,
-    ) -> Option<(Self::LinkEndpoint, Self::LinkEndpoint)> {
-        self.get_connections(from, to).next()
-    }
-
-    /// Checks whether there is a directed link between the two nodes.
-    ///
-    /// # Example
-    /// ```
-    /// # use portgraph::{PortGraph, NodeIndex, PortIndex, Direction, PortView, LinkView};
-    /// let mut g = PortGraph::new();
-    /// let a = g.add_node(0, 2);
-    /// let b = g.add_node(2, 0);
-    ///
-    /// g.link_nodes(a, 0, b, 0).unwrap();
-    ///
-    /// assert!(g.connected(a, b));
-    /// ```
-    #[must_use]
-    #[inline]
-    fn connected(&self, from: NodeIndex, to: NodeIndex) -> bool {
-        self.get_connection(from, to).is_some()
-    }
-
-    /// Returns the port that the given `port` is linked to.
-    #[must_use]
-    fn port_links(&self, port: PortIndex) -> Self::PortLinks<'_>;
-
-    /// Return the link to the provided port, if not connected return None.
-    /// If this port has multiple connected subports, an arbitrary one is returned.
-    #[must_use]
-    #[inline]
-    fn port_link(&self, port: PortIndex) -> Option<Self::LinkEndpoint> {
-        self.port_links(port).next().map(|(_, p)| p)
-    }
-
-    /// Iterates over the connected links of the `node` in the given
-    /// `direction`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use portgraph::{PortGraph, PortView, LinkView, MultiView};
-    /// # use portgraph::Direction;
-    ///
-    /// let mut graph = PortGraph::new();
-    ///
-    /// let node_a = graph.add_node(0, 2);
-    /// let node_b = graph.add_node(1, 0);
-    ///
-    /// let port_a = graph.outputs(node_a).next().unwrap();
-    /// let port_b = graph.inputs(node_b).next().unwrap();
-    ///
-    /// graph.link_ports(port_a, port_b).unwrap();
-    ///
-    /// assert!(graph.links(node_a, Direction::Outgoing).eq([(port_a, port_b)]));
-    /// assert!(graph.links(node_b, Direction::Incoming).eq([(port_b, port_a)]));
-    /// ```
-    #[must_use]
-    fn links(&self, node: NodeIndex, direction: Direction) -> Self::NodeLinks<'_>;
-
-    /// Iterates over the connected input and output links of the `node` in sequence.
-    #[must_use]
-    fn all_links(&self, node: NodeIndex) -> Self::NodeLinks<'_>;
-
-    /// Iterates over the connected input links of the `node`. Shorthand for
-    /// [`LinkView::links`].
-    #[must_use]
-    #[inline]
-    fn input_links(&self, node: NodeIndex) -> Self::NodeLinks<'_> {
-        self.links(node, Direction::Incoming)
-    }
-
-    /// Iterates over the connected output links of the `node`. Shorthand for
-    /// [`LinkView::links`].
-    #[must_use]
-    #[inline]
-    fn output_links(&self, node: NodeIndex) -> Self::NodeLinks<'_> {
-        self.links(node, Direction::Outgoing)
-    }
-
-    /// Iterates over neighbour nodes in the given `direction`.
-    /// May contain duplicates if the graph has multiple links between nodes.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use portgraph::{PortGraph, PortView, LinkView};
-    /// # use portgraph::Direction;
-    ///
-    /// let mut graph = PortGraph::new();
-    ///
-    /// let a = graph.add_node(0, 1);
-    /// let b = graph.add_node(2, 1);
-    ///
-    /// graph.link_nodes(a, 0, b, 0).unwrap();
-    /// graph.link_nodes(b, 0, b, 1).unwrap();
-    ///
-    /// assert!(graph.neighbours(a, Direction::Outgoing).eq([b]));
-    /// assert!(graph.neighbours(b, Direction::Incoming).eq([a,b]));
-    /// ```
-    #[must_use]
-    fn neighbours(&self, node: NodeIndex, direction: Direction) -> Self::Neighbours<'_>;
-
-    /// Iterates over the input and output neighbours of the `node` in sequence.
-    #[must_use]
-    fn all_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_>;
-
-    /// Iterates over the input neighbours of the `node`. Shorthand for [`LinkView::neighbours`].
-    #[must_use]
-    #[inline]
-    fn input_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_> {
-        self.neighbours(node, Direction::Incoming)
-    }
-
-    /// Iterates over the output neighbours of the `node`. Shorthand for [`LinkView::neighbours`].
-    #[must_use]
-    #[inline]
-    fn output_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_> {
-        self.neighbours(node, Direction::Outgoing)
-    }
-
-    /// Returns the number of links between ports.
-    #[must_use]
-    fn link_count(&self) -> usize;
 }
 
 /// Abstraction over a portgraph that may have multiple connections per node.
@@ -550,23 +550,6 @@ pub trait MultiView: LinkView {
     type NodeSubports<'a>: Iterator<Item = Self::SubportIndex>
     where
         Self: 'a;
-
-    /// Link an output subport to an input subport.
-    ///
-    /// # Errors
-    ///
-    ///  - If `subport_from` or `subport_to` does not exist.
-    ///  - If `subport_a` and `subport_b` have the same direction.
-    ///  - If `subport_from` or `subport_to` is already linked.
-    fn link_subports(
-        &mut self,
-        subport_from: Self::SubportIndex,
-        subport_to: Self::SubportIndex,
-    ) -> Result<(), LinkError>;
-
-    /// Unlinks the `port` and returns the subport it was linked to. Returns `None`
-    /// when the port was not linked.
-    fn unlink_subport(&mut self, subport: Self::SubportIndex) -> Option<Self::SubportIndex>;
 
     /// Return the subport linked to the given `port`. If the port is not
     /// connected, return None.
@@ -598,4 +581,24 @@ pub trait MultiView: LinkView {
     fn subport_outputs(&self, node: NodeIndex) -> Self::NodeSubports<'_> {
         self.subports(node, Direction::Outgoing)
     }
+}
+
+/// Abstraction for mutating a portgraph that may have multiple connections per node.
+pub trait MultiMut: MultiView + LinkMut {
+    /// Link an output subport to an input subport.
+    ///
+    /// # Errors
+    ///
+    ///  - If `subport_from` or `subport_to` does not exist.
+    ///  - If `subport_a` and `subport_b` have the same direction.
+    ///  - If `subport_from` or `subport_to` is already linked.
+    fn link_subports(
+        &mut self,
+        subport_from: Self::SubportIndex,
+        subport_to: Self::SubportIndex,
+    ) -> Result<(), LinkError>;
+
+    /// Unlinks the `port` and returns the subport it was linked to. Returns `None`
+    /// when the port was not linked.
+    fn unlink_subport(&mut self, subport: Self::SubportIndex) -> Option<Self::SubportIndex>;
 }

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -11,8 +11,7 @@
 //! # Example
 //!
 //! ```
-//! # use portgraph::{PortGraph, NodeIndex, PortIndex, PortView, LinkView};
-//! # use portgraph::weights::Weights;
+//! # use ::portgraph::*;
 //! let mut graph = PortGraph::new();
 //! let mut weights = Weights::<usize, isize>::new();
 //!


### PR DESCRIPTION
Splits `PortView`, `LinkView`, and `MultiView`. Adds `*Mut` traits with the mutable methods.
The method definitions are left unchanged.

With this we will be able to define read-only graph adaptors (in an upcoming PR).