### PR TITLE
Graph filter adaptors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ serde = { version = "1.0.152", features = ["derive"], optional = true}
 proptest = { version = "1.1.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 petgraph = { version = "0.6.3", optional = true }
+delegate = "0.9.0"
+context-iterators = "0.1.0"
 
 [features]
 pyo3 = ["dep:pyo3"]

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,5 +1,8 @@
 //! Abstractions over portgraph representations.
 
+pub mod filter;
+pub mod region;
+
 #[cfg(feature = "petgraph")]
 pub mod petgraph;
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -8,6 +8,9 @@ pub mod petgraph;
 
 use crate::{portgraph::PortOperation, Direction, LinkError, NodeIndex, PortIndex, PortOffset};
 
+pub use filter::{NodeFilter, NodeFiltered};
+pub use region::{FlatRegion, Region};
+
 /// Core capabilities for querying a graph containing nodes and ports.
 pub trait PortView {
     /// Iterator over the nodes of the graph.

--- a/src/view/filter.rs
+++ b/src/view/filter.rs
@@ -9,6 +9,7 @@ use delegate::delegate;
 pub type NodeFilter<Ctx> = fn(NodeIndex, &Ctx) -> bool;
 
 /// A wrapper around a portgraph that filters out nodes.
+#[derive(Debug, Clone, PartialEq)]
 pub struct NodeFiltered<'a, G, F, Context = ()> {
     graph: &'a G,
     filter: F,

--- a/src/view/filter.rs
+++ b/src/view/filter.rs
@@ -83,25 +83,22 @@ impl<'a, G, Ctx> NodeFilterCtx<'a, G, Ctx> {
     }
 }
 
-/// Non-capturing filter function used in [`NodeFilteredNodes`].
-/// This
+/// Non-capturing filter function used by [`NodeFiltered`].
 type NodeFilterFn<Item, G, Ctx> = fn(&Item, &NodeFilterCtx<G, Ctx>) -> bool;
+
+/// Node-filtered iterator wrapper used by [`NodeFiltered`].
+pub type NodeFilteredIter<'a, G, Ctx, I> =
+    FilterCtx<WithCtx<I, NodeFilterCtx<'a, G, Ctx>>, NodeFilterFn<<I as Iterator>::Item, G, Ctx>>;
 
 impl<G, Ctx> PortView for NodeFiltered<'_, G, NodeFilter<Ctx>, Ctx>
 where
     G: PortView,
 {
-    type Nodes<'a> = FilterCtx<
-        WithCtx<<G as PortView>::Nodes<'a>, NodeFilterCtx<'a, G, Ctx>>,
-        NodeFilterFn<NodeIndex, G, Ctx>,
-    >
+    type Nodes<'a> = NodeFilteredIter<'a, G, Ctx, <G as PortView>::Nodes<'a>>
     where
         Self: 'a;
 
-    type Ports<'a> = FilterCtx<
-        WithCtx<<G as PortView>::Ports<'a>, NodeFilterCtx<'a, G, Ctx>>,
-        NodeFilterFn<PortIndex, G, Ctx>,
-    >
+    type Ports<'a> = NodeFilteredIter<'a, G, Ctx, <G as PortView>::Ports<'a>>
     where
         Self: 'a;
 
@@ -185,31 +182,19 @@ where
 {
     type LinkEndpoint = G::LinkEndpoint;
 
-    type Neighbours<'a> = FilterCtx<
-        WithCtx<<G as LinkView>::Neighbours<'a>, NodeFilterCtx<'a, G, Ctx>>,
-        NodeFilterFn<NodeIndex, G, Ctx>,
-    >
+    type Neighbours<'a> = NodeFilteredIter<'a, G, Ctx, <G as LinkView>::Neighbours<'a>>
     where
         Self: 'a;
 
-    type NodeConnections<'a> = FilterCtx<
-        WithCtx<<G as LinkView>::NodeConnections<'a>, NodeFilterCtx<'a, G, Ctx>>,
-        NodeFilterFn<(Self::LinkEndpoint, Self::LinkEndpoint), G, Ctx>,
-    >
+    type NodeConnections<'a> = NodeFilteredIter<'a, G, Ctx, <G as LinkView>::NodeConnections<'a>>
     where
         Self: 'a;
 
-    type NodeLinks<'a> = FilterCtx<
-        WithCtx<<G as LinkView>::NodeLinks<'a>, NodeFilterCtx<'a, G, Ctx>>,
-        NodeFilterFn<(Self::LinkEndpoint, Self::LinkEndpoint), G, Ctx>,
-    >
+    type NodeLinks<'a> = NodeFilteredIter<'a, G, Ctx, <G as LinkView>::NodeLinks<'a>>
     where
         Self: 'a;
 
-    type PortLinks<'a> = FilterCtx<
-        WithCtx<<G as LinkView>::PortLinks<'a>, NodeFilterCtx<'a, G, Ctx>>,
-        NodeFilterFn<(Self::LinkEndpoint, Self::LinkEndpoint), G, Ctx>,
-    >
+    type PortLinks<'a> = NodeFilteredIter<'a, G, Ctx, <G as LinkView>::PortLinks<'a>>
     where
         Self: 'a;
 
@@ -266,10 +251,7 @@ impl<G, Ctx> MultiView for NodeFiltered<'_, G, NodeFilter<Ctx>, Ctx>
 where
     G: MultiView,
 {
-    type NodeSubports<'a> = FilterCtx<
-        WithCtx<<G as MultiView>::NodeSubports<'a>, NodeFilterCtx<'a, G, Ctx>>,
-        NodeFilterFn<Self::LinkEndpoint, G, Ctx>,
-    >
+    type NodeSubports<'a> = NodeFilteredIter<'a, G, Ctx, <G as MultiView>::NodeSubports<'a>>
     where
         Self: 'a;
 

--- a/src/view/filter.rs
+++ b/src/view/filter.rs
@@ -1,0 +1,294 @@
+//! Wrappers around portgraphs to filter out nodes and ports.
+
+use crate::{Direction, LinkView, MultiView, NodeIndex, PortIndex, PortView};
+
+use context_iterators::{ContextIterator, FilterCtx, IntoContextIterator, WithCtx};
+use delegate::delegate;
+
+/// Node filter used by [`NodeFiltered`].
+pub type NodeFilter<Ctx> = fn(NodeIndex, &Ctx) -> bool;
+
+/// A wrapper around a portgraph that filters out nodes.
+pub struct NodeFiltered<'a, G, F, Context = ()> {
+    graph: &'a G,
+    filter: F,
+    context: Context,
+}
+
+impl<'a, G, F, Ctx> NodeFiltered<'a, G, F, Ctx> {
+    /// Create a new node filtered portgraph.
+    pub fn new(graph: &'a G, filter: F, context: Ctx) -> Self {
+        Self {
+            graph,
+            filter,
+            context,
+        }
+    }
+
+    /// Get the filter's context.
+    pub fn context(&self) -> &Ctx {
+        &self.context
+    }
+}
+
+/// Filter functions used on the items of the [`NodeFiltered`] iterators.
+impl<G, Ctx> NodeFiltered<'_, G, NodeFilter<Ctx>, Ctx> {
+    /// Node filter used for the iterators
+    fn node_filter(node: &NodeIndex, ctx: &NodeFilterCtx<G, Ctx>) -> bool
+    where
+        G: PortView,
+    {
+        (ctx.filter)(*node, ctx.context)
+    }
+
+    /// Port filter used for the iterators
+    fn port_filter(port: &(impl Into<PortIndex> + Copy), ctx: &NodeFilterCtx<G, Ctx>) -> bool
+    where
+        G: PortView,
+    {
+        let node = ctx.graph.port_node(*port).unwrap();
+        (ctx.filter)(node, ctx.context)
+    }
+
+    /// Link filter used for the iterators
+    fn link_filter(link: &(G::LinkEndpoint, G::LinkEndpoint), ctx: &NodeFilterCtx<G, Ctx>) -> bool
+    where
+        G: LinkView,
+    {
+        let (from, to) = link;
+        let from_node = ctx.graph.port_node(*from).unwrap();
+        let to_node = ctx.graph.port_node(*to).unwrap();
+        (ctx.filter)(from_node, ctx.context) && (ctx.filter)(to_node, ctx.context)
+    }
+}
+
+/// Context used internally for the [`NodeFiltered`] iterators.
+///
+/// This is a named struct to make the iterator signatures more readable.
+pub struct NodeFilterCtx<'a, G, Ctx> {
+    pub(self) graph: &'a G,
+    pub(self) filter: NodeFilter<Ctx>,
+    pub(self) context: &'a Ctx,
+}
+
+impl<'a, G, Ctx> NodeFilterCtx<'a, G, Ctx> {
+    /// Create a new context.
+    pub(self) fn new(graph: &'a G, filter: NodeFilter<Ctx>, context: &'a Ctx) -> Self {
+        Self {
+            graph,
+            filter,
+            context,
+        }
+    }
+}
+
+/// Non-capturing filter function used in [`NodeFilteredNodes`].
+/// This
+type NodeFilterFn<Item, G, Ctx> = fn(&Item, &NodeFilterCtx<G, Ctx>) -> bool;
+
+impl<G, Ctx> PortView for NodeFiltered<'_, G, NodeFilter<Ctx>, Ctx>
+where
+    G: PortView,
+{
+    type Nodes<'a> = FilterCtx<
+        WithCtx<<G as PortView>::Nodes<'a>, NodeFilterCtx<'a, G, Ctx>>,
+        NodeFilterFn<NodeIndex, G, Ctx>,
+    >
+    where
+        Self: 'a;
+
+    type Ports<'a> = FilterCtx<
+        WithCtx<<G as PortView>::Ports<'a>, NodeFilterCtx<'a, G, Ctx>>,
+        NodeFilterFn<PortIndex, G, Ctx>,
+    >
+    where
+        Self: 'a;
+
+    type NodePorts<'a> = G::NodePorts<'a>
+    where
+        Self: 'a;
+
+    type NodePortOffsets<'a> = G::NodePortOffsets<'a>
+    where
+        Self: 'a;
+
+    #[inline]
+    fn contains_node(&'_ self, node: NodeIndex) -> bool {
+        self.graph.contains_node(node) && (self.filter)(node, &self.context)
+    }
+
+    #[inline]
+    fn contains_port(&self, port: PortIndex) -> bool {
+        if self.graph.contains_port(port) {
+            let node = self.graph.port_node(port).unwrap();
+            (self.filter)(node, &self.context)
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.node_count() == 0
+    }
+
+    #[inline]
+    fn node_count(&self) -> usize {
+        self.nodes_iter().count()
+    }
+
+    #[inline]
+    fn port_count(&self) -> usize {
+        self.ports_iter().count()
+    }
+
+    #[inline]
+    fn nodes_iter(&self) -> Self::Nodes<'_> {
+        self.graph
+            .nodes_iter()
+            .with_context(NodeFilterCtx::new(self.graph, self.filter, &self.context))
+            .filter_with_context(Self::node_filter)
+    }
+
+    #[inline]
+    fn ports_iter(&self) -> Self::Ports<'_> {
+        self.graph
+            .ports_iter()
+            .with_context(NodeFilterCtx::new(self.graph, self.filter, &self.context))
+            .filter_with_context(Self::port_filter)
+    }
+
+    delegate! {
+        to self.graph {
+            fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction>;
+            fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
+            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<crate::PortOffset>;
+            fn port_index(&self, node: NodeIndex, offset: crate::PortOffset) -> Option<PortIndex>;
+            fn ports(&self, node: NodeIndex, direction: Direction) -> Self::NodePorts<'_>;
+            fn all_ports(&self, node: NodeIndex) -> Self::NodePorts<'_>;
+            fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
+            fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
+            fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> Self::NodePortOffsets<'_>;
+            fn all_port_offsets(&self, node: NodeIndex) -> Self::NodePortOffsets<'_>;
+            fn node_capacity(&self) -> usize;
+            fn port_capacity(&self) -> usize;
+            fn node_port_capacity(&self, node: NodeIndex) -> usize;
+        }
+    }
+}
+
+impl<G, Ctx> LinkView for NodeFiltered<'_, G, NodeFilter<Ctx>, Ctx>
+where
+    G: LinkView,
+{
+    type LinkEndpoint = G::LinkEndpoint;
+
+    type Neighbours<'a> = FilterCtx<
+        WithCtx<<G as LinkView>::Neighbours<'a>, NodeFilterCtx<'a, G, Ctx>>,
+        NodeFilterFn<NodeIndex, G, Ctx>,
+    >
+    where
+        Self: 'a;
+
+    type NodeConnections<'a> = FilterCtx<
+        WithCtx<<G as LinkView>::NodeConnections<'a>, NodeFilterCtx<'a, G, Ctx>>,
+        NodeFilterFn<(Self::LinkEndpoint, Self::LinkEndpoint), G, Ctx>,
+    >
+    where
+        Self: 'a;
+
+    type NodeLinks<'a> = FilterCtx<
+        WithCtx<<G as LinkView>::NodeLinks<'a>, NodeFilterCtx<'a, G, Ctx>>,
+        NodeFilterFn<(Self::LinkEndpoint, Self::LinkEndpoint), G, Ctx>,
+    >
+    where
+        Self: 'a;
+
+    type PortLinks<'a> = FilterCtx<
+        WithCtx<<G as LinkView>::PortLinks<'a>, NodeFilterCtx<'a, G, Ctx>>,
+        NodeFilterFn<(Self::LinkEndpoint, Self::LinkEndpoint), G, Ctx>,
+    >
+    where
+        Self: 'a;
+
+    fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> Self::NodeConnections<'_> {
+        self.graph
+            .get_connections(from, to)
+            .with_context(NodeFilterCtx::new(self.graph, self.filter, &self.context))
+            .filter_with_context(Self::link_filter)
+    }
+
+    fn port_links(&self, port: PortIndex) -> Self::PortLinks<'_> {
+        self.graph
+            .port_links(port)
+            .with_context(NodeFilterCtx::new(self.graph, self.filter, &self.context))
+            .filter_with_context(Self::link_filter)
+    }
+
+    fn links(&self, node: NodeIndex, direction: Direction) -> Self::NodeLinks<'_> {
+        self.graph
+            .links(node, direction)
+            .with_context(NodeFilterCtx::new(self.graph, self.filter, &self.context))
+            .filter_with_context(Self::link_filter)
+    }
+
+    fn all_links(&self, node: NodeIndex) -> Self::NodeLinks<'_> {
+        self.graph
+            .all_links(node)
+            .with_context(NodeFilterCtx::new(self.graph, self.filter, &self.context))
+            .filter_with_context(Self::link_filter)
+    }
+
+    fn neighbours(&self, node: NodeIndex, direction: Direction) -> Self::Neighbours<'_> {
+        self.graph
+            .neighbours(node, direction)
+            .with_context(NodeFilterCtx::new(self.graph, self.filter, &self.context))
+            .filter_with_context(Self::node_filter)
+    }
+
+    fn all_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_> {
+        self.graph
+            .all_neighbours(node)
+            .with_context(NodeFilterCtx::new(self.graph, self.filter, &self.context))
+            .filter_with_context(Self::node_filter)
+    }
+
+    fn link_count(&self) -> usize {
+        self.nodes_iter()
+            .flat_map(|node| self.all_links(node))
+            .count()
+    }
+}
+
+impl<G, Ctx> MultiView for NodeFiltered<'_, G, NodeFilter<Ctx>, Ctx>
+where
+    G: MultiView,
+{
+    type NodeSubports<'a> = FilterCtx<
+        WithCtx<<G as MultiView>::NodeSubports<'a>, NodeFilterCtx<'a, G, Ctx>>,
+        NodeFilterFn<Self::LinkEndpoint, G, Ctx>,
+    >
+    where
+        Self: 'a;
+
+    fn subports(&self, node: NodeIndex, direction: Direction) -> Self::NodeSubports<'_> {
+        self.graph
+            .subports(node, direction)
+            .with_context(NodeFilterCtx::new(self.graph, self.filter, &self.context))
+            .filter_with_context(Self::port_filter)
+    }
+
+    fn all_subports(&self, node: NodeIndex) -> Self::NodeSubports<'_> {
+        self.graph
+            .all_subports(node)
+            .with_context(NodeFilterCtx::new(self.graph, self.filter, &self.context))
+            .filter_with_context(Self::port_filter)
+    }
+
+    delegate! {
+        to self.graph {
+            fn subport_link(&self, subport: Self::LinkEndpoint) -> Option<Self::LinkEndpoint>;
+        }
+    }
+}

--- a/src/view/region.rs
+++ b/src/view/region.rs
@@ -41,7 +41,7 @@ impl<'a, G> Region<'a, G> {
     }
 }
 
-/// Internal context used in the [`Region`] iterators.
+/// Internal context used in the [`Region`] adaptor.
 #[derive(Debug, Clone)]
 pub struct RegionContext<'g> {
     hierarchy: &'g Hierarchy,

--- a/src/view/region.rs
+++ b/src/view/region.rs
@@ -1,0 +1,133 @@
+//! View of a portgraph containing only the children of a node in a [`Hierarchy`].
+
+use super::filter::NodeFiltered;
+use crate::{Direction, Hierarchy, LinkView, MultiView, NodeIndex, PortIndex, PortView};
+
+use delegate::delegate;
+
+type RegionContext<'g> = (&'g Hierarchy, NodeIndex);
+type RegionCallback<'g> = fn(NodeIndex, &RegionContext<'g>) -> bool;
+type RegionInternalGraph<'g, G> = NodeFiltered<'g, G, RegionCallback<'g>, RegionContext<'g>>;
+
+/// View of a portgraph containing only the children of a node in a [`Hierarchy`].
+pub struct Region<'g, G> {
+    graph: RegionInternalGraph<'g, G>,
+    root: NodeIndex,
+}
+
+impl<'a, G> Region<'a, G> {
+    /// Create a new region view.
+    pub fn new(graph: &'a G, hierarchy: &'a Hierarchy, root: NodeIndex) -> Self {
+        let region_filter: RegionCallback<'a> = |node, context| {
+            let (hierarchy, root) = context;
+            hierarchy.parent(node) == Some(*root)
+        };
+        Self {
+            graph: NodeFiltered::new(graph, region_filter, (hierarchy, root)),
+            root,
+        }
+    }
+
+    /// Get the root node of the region.
+    pub fn root(&self) -> NodeIndex {
+        self.root
+    }
+}
+
+impl<'g, G> PortView for Region<'g, G>
+where
+    G: PortView,
+{
+    type Nodes<'a> = <RegionInternalGraph<'g, G> as PortView>::Nodes<'a>
+    where
+        Self: 'a;
+
+    type Ports<'a> = <RegionInternalGraph<'g, G> as PortView>::Ports<'a>
+    where
+        Self: 'a;
+
+    type NodePorts<'a> = <RegionInternalGraph<'g, G> as PortView>::NodePorts<'a>
+    where
+        Self: 'a;
+
+    type NodePortOffsets<'a> = <RegionInternalGraph<'g, G> as PortView>::NodePortOffsets<'a>
+    where
+        Self: 'a;
+
+    delegate! {
+        to self.graph {
+            fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction>;
+            fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
+            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<crate::PortOffset>;
+            fn port_index(&self, node: NodeIndex, offset: crate::PortOffset) -> Option<PortIndex>;
+            fn ports(&self, node: NodeIndex, direction: Direction) -> Self::NodePorts<'_>;
+            fn all_ports(&self, node: NodeIndex) -> Self::NodePorts<'_>;
+            fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
+            fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
+            fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> Self::NodePortOffsets<'_>;
+            fn all_port_offsets(&self, node: NodeIndex) -> Self::NodePortOffsets<'_>;
+            fn contains_node(&self, node: NodeIndex) -> bool;
+            fn contains_port(&self, port: PortIndex) -> bool;
+            fn is_empty(&self) -> bool;
+            fn node_count(&self) -> usize;
+            fn port_count(&self) -> usize;
+            fn nodes_iter(&self) -> Self::Nodes<'_>;
+            fn ports_iter(&self) -> Self::Ports<'_>;
+            fn node_capacity(&self) -> usize;
+            fn port_capacity(&self) -> usize;
+            fn node_port_capacity(&self, node: NodeIndex) -> usize;
+        }
+    }
+}
+
+impl<'g, G> LinkView for Region<'g, G>
+where
+    G: LinkView,
+{
+    type LinkEndpoint = G::LinkEndpoint;
+
+    type Neighbours<'a> = <RegionInternalGraph<'g, G> as LinkView>::Neighbours<'a>
+    where
+        Self: 'a;
+
+    type NodeConnections<'a> = <RegionInternalGraph<'g, G> as LinkView>::NodeConnections<'a>
+    where
+        Self: 'a;
+
+    type NodeLinks<'a> = <RegionInternalGraph<'g, G> as LinkView>::NodeLinks<'a>
+    where
+        Self: 'a;
+
+    type PortLinks<'a> = <RegionInternalGraph<'g, G> as LinkView>::PortLinks<'a>
+    where
+        Self: 'a;
+
+    delegate! {
+        to self.graph {
+            fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> Self::NodeConnections<'_>;
+            fn port_links(&self, port: PortIndex) -> Self::PortLinks<'_>;
+            fn links(&self, node: NodeIndex, direction: Direction) -> Self::NodeLinks<'_>;
+            fn all_links(&self, node: NodeIndex) -> Self::NodeLinks<'_>;
+            fn neighbours(&self, node: NodeIndex, direction: Direction) -> Self::Neighbours<'_>;
+            fn all_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_>;
+            fn link_count(&self) -> usize;
+        }
+    }
+}
+
+impl<'g, G> MultiView for Region<'g, G>
+where
+    G: MultiView,
+{
+    type NodeSubports<'a> = <RegionInternalGraph<'g, G> as MultiView>::NodeSubports<'a>
+    where
+        Self: 'a;
+
+    delegate! {
+            to self.graph {
+        fn subport_link(&self, subport: Self::LinkEndpoint) -> Option<Self::LinkEndpoint>;
+        fn subports(&self, node: NodeIndex, direction: Direction) -> Self::NodeSubports<'_>;
+        fn all_subports(&self, node: NodeIndex) -> Self::NodeSubports<'_>;
+    }}
+}

--- a/src/view/region.rs
+++ b/src/view/region.rs
@@ -1,29 +1,36 @@
-//! View of a portgraph containing only the children of a node in a [`Hierarchy`].
+//! View of a portgraph containing only the descendants of a node in a [`Hierarchy`].
+
+use std::{cell::RefCell, collections::HashMap, iter};
 
 use super::filter::NodeFiltered;
 use crate::{Direction, Hierarchy, LinkView, MultiView, NodeIndex, PortIndex, PortView};
 
 use delegate::delegate;
 
-type RegionContext<'g> = (&'g Hierarchy, NodeIndex);
 type RegionCallback<'g> = fn(NodeIndex, &RegionContext<'g>) -> bool;
 type RegionInternalGraph<'g, G> = NodeFiltered<'g, G, RegionCallback<'g>, RegionContext<'g>>;
 
-/// View of a portgraph containing only the children of a node in a [`Hierarchy`].
+/// View of a portgraph containing only the descendants of a node in a
+/// [`Hierarchy`].
+///
+/// For a view of a portgraph containing only the direct children of a node, see
+/// [`FlatRegion`]. Prefer using [`FlatRegion`] if possible, as it is more
+/// efficient.
+///
+/// [`Region`] does not implement `Sync` as it uses a [`RefCell`] to cache the
+/// node filtering.
+#[derive(Debug, Clone)]
 pub struct Region<'g, G> {
     graph: RegionInternalGraph<'g, G>,
     root: NodeIndex,
 }
 
 impl<'a, G> Region<'a, G> {
-    /// Create a new region view.
+    /// Create a new region view including all the descendants of the root node.
     pub fn new(graph: &'a G, hierarchy: &'a Hierarchy, root: NodeIndex) -> Self {
-        let region_filter: RegionCallback<'a> = |node, context| {
-            let (hierarchy, root) = context;
-            hierarchy.parent(node) == Some(*root)
-        };
+        let region_filter: RegionCallback<'a> = |node, context| context.is_descendant(node);
         Self {
-            graph: NodeFiltered::new(graph, region_filter, (hierarchy, root)),
+            graph: NodeFiltered::new(graph, region_filter, RegionContext::new(hierarchy, root)),
             root,
         }
     }
@@ -31,6 +38,60 @@ impl<'a, G> Region<'a, G> {
     /// Get the root node of the region.
     pub fn root(&self) -> NodeIndex {
         self.root
+    }
+}
+
+/// Internal context used in the [`Region`] iterators.
+#[derive(Debug, Clone)]
+pub struct RegionContext<'g> {
+    hierarchy: &'g Hierarchy,
+    root: NodeIndex,
+    /// Cache of the result of the [`is_descendant`] check.
+    is_descendant: RefCell<HashMap<NodeIndex, bool>>,
+}
+
+impl<'g> RegionContext<'g> {
+    /// Create a new [`RegionContext`].
+    pub fn new(hierarchy: &'g Hierarchy, root: NodeIndex) -> Self {
+        let mut is_descendant = HashMap::new();
+        is_descendant.insert(root, false);
+        Self {
+            hierarchy,
+            root,
+            is_descendant: RefCell::new(is_descendant),
+        }
+    }
+
+    /// Check if a node is a descendant of the root node.
+    ///
+    /// Caches the result of the check.
+    pub fn is_descendant(&self, node: NodeIndex) -> bool {
+        if let Some(is_descendant) = self.is_descendant.borrow().get(&node) {
+            // We have already checked this node.
+            return *is_descendant;
+        }
+        // Traverse the ancestors until we see a node we have already checked.
+        let cache = self.is_descendant.borrow();
+        let ancestors: Vec<_> = iter::successors(Some(node), |node| {
+            let parent = self.hierarchy.parent(*node)?;
+            match cache.contains_key(&parent) {
+                true => None,
+                false => Some(parent),
+            }
+        })
+        .collect();
+        let first_visited_ancestor = self.hierarchy.parent(*ancestors.last().unwrap());
+        let is_descendant = first_visited_ancestor == Some(self.root)
+            || first_visited_ancestor
+                .map_or(false, |ancestor| cache.get(&ancestor).copied().unwrap());
+        drop(cache);
+
+        // Update the cache for all the unvisited ancestors.
+        let mut cache_mut = self.is_descendant.borrow_mut();
+        for node in ancestors {
+            cache_mut.insert(node, is_descendant);
+        }
+        is_descendant
     }
 }
 
@@ -132,6 +193,137 @@ where
     }}
 }
 
+type FlatRegionContext<'g> = (&'g Hierarchy, NodeIndex);
+type FlatRegionCallback<'g> = fn(NodeIndex, &FlatRegionContext<'g>) -> bool;
+type FlatRegionInternalGraph<'g, G> =
+    NodeFiltered<'g, G, FlatRegionCallback<'g>, FlatRegionContext<'g>>;
+
+/// View of a portgraph containing only the direct children of a node in a [`Hierarchy`].
+///
+/// For a view of all descendants, see [`Region`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct FlatRegion<'g, G> {
+    graph: FlatRegionInternalGraph<'g, G>,
+    root: NodeIndex,
+}
+
+impl<'a, G> FlatRegion<'a, G> {
+    /// Create a new region view including all the descendants of the root node.
+    pub fn new(graph: &'a G, hierarchy: &'a Hierarchy, root: NodeIndex) -> Self {
+        let region_filter: FlatRegionCallback<'a> = |node, context| {
+            let (hierarchy, root) = context;
+            hierarchy.parent(node) == Some(*root)
+        };
+        Self {
+            graph: NodeFiltered::new(graph, region_filter, (hierarchy, root)),
+            root,
+        }
+    }
+
+    /// Get the root node of the region.
+    pub fn root(&self) -> NodeIndex {
+        self.root
+    }
+}
+
+impl<'g, G> PortView for FlatRegion<'g, G>
+where
+    G: PortView,
+{
+    type Nodes<'a> = <FlatRegionInternalGraph<'g, G> as PortView>::Nodes<'a>
+    where
+        Self: 'a;
+
+    type Ports<'a> = <FlatRegionInternalGraph<'g, G> as PortView>::Ports<'a>
+    where
+        Self: 'a;
+
+    type NodePorts<'a> = <FlatRegionInternalGraph<'g, G> as PortView>::NodePorts<'a>
+    where
+        Self: 'a;
+
+    type NodePortOffsets<'a> = <FlatRegionInternalGraph<'g, G> as PortView>::NodePortOffsets<'a>
+    where
+        Self: 'a;
+
+    delegate! {
+        to self.graph {
+            fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction>;
+            fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
+            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<crate::PortOffset>;
+            fn port_index(&self, node: NodeIndex, offset: crate::PortOffset) -> Option<PortIndex>;
+            fn ports(&self, node: NodeIndex, direction: Direction) -> Self::NodePorts<'_>;
+            fn all_ports(&self, node: NodeIndex) -> Self::NodePorts<'_>;
+            fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
+            fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
+            fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> Self::NodePortOffsets<'_>;
+            fn all_port_offsets(&self, node: NodeIndex) -> Self::NodePortOffsets<'_>;
+            fn contains_node(&self, node: NodeIndex) -> bool;
+            fn contains_port(&self, port: PortIndex) -> bool;
+            fn is_empty(&self) -> bool;
+            fn node_count(&self) -> usize;
+            fn port_count(&self) -> usize;
+            fn nodes_iter(&self) -> Self::Nodes<'_>;
+            fn ports_iter(&self) -> Self::Ports<'_>;
+            fn node_capacity(&self) -> usize;
+            fn port_capacity(&self) -> usize;
+            fn node_port_capacity(&self, node: NodeIndex) -> usize;
+        }
+    }
+}
+
+impl<'g, G> LinkView for FlatRegion<'g, G>
+where
+    G: LinkView,
+{
+    type LinkEndpoint = G::LinkEndpoint;
+
+    type Neighbours<'a> = <FlatRegionInternalGraph<'g, G> as LinkView>::Neighbours<'a>
+    where
+        Self: 'a;
+
+    type NodeConnections<'a> = <FlatRegionInternalGraph<'g, G> as LinkView>::NodeConnections<'a>
+    where
+        Self: 'a;
+
+    type NodeLinks<'a> = <FlatRegionInternalGraph<'g, G> as LinkView>::NodeLinks<'a>
+    where
+        Self: 'a;
+
+    type PortLinks<'a> = <FlatRegionInternalGraph<'g, G> as LinkView>::PortLinks<'a>
+    where
+        Self: 'a;
+
+    delegate! {
+        to self.graph {
+            fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> Self::NodeConnections<'_>;
+            fn port_links(&self, port: PortIndex) -> Self::PortLinks<'_>;
+            fn links(&self, node: NodeIndex, direction: Direction) -> Self::NodeLinks<'_>;
+            fn all_links(&self, node: NodeIndex) -> Self::NodeLinks<'_>;
+            fn neighbours(&self, node: NodeIndex, direction: Direction) -> Self::Neighbours<'_>;
+            fn all_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_>;
+            fn link_count(&self) -> usize;
+        }
+    }
+}
+
+impl<'g, G> MultiView for FlatRegion<'g, G>
+where
+    G: MultiView,
+{
+    type NodeSubports<'a> = <FlatRegionInternalGraph<'g, G> as MultiView>::NodeSubports<'a>
+    where
+        Self: 'a;
+
+    delegate! {
+            to self.graph {
+        fn subport_link(&self, subport: Self::LinkEndpoint) -> Option<Self::LinkEndpoint>;
+        fn subports(&self, node: NodeIndex, direction: Direction) -> Self::NodeSubports<'_>;
+        fn all_subports(&self, node: NodeIndex) -> Self::NodeSubports<'_>;
+    }}
+}
+
 #[cfg(test)]
 mod test {
     use std::error::Error;
@@ -147,10 +339,42 @@ mod test {
 
         let hierarchy = Hierarchy::new();
 
+        let region = FlatRegion::new(&graph, &hierarchy, root);
+        assert!(region.is_empty());
+        assert_eq!(region.node_count(), 0);
+        assert_eq!(region.port_count(), 0);
+
         let region = Region::new(&graph, &hierarchy, root);
         assert!(region.is_empty());
         assert_eq!(region.node_count(), 0);
         assert_eq!(region.port_count(), 0);
+    }
+
+    #[test]
+    fn simple_flat_region() -> Result<(), Box<dyn Error>> {
+        let mut graph = PortGraph::new();
+        let root = graph.add_node(42, 0);
+        let a = graph.add_node(1, 2);
+        let b = graph.add_node(0, 0);
+        let c = graph.add_node(0, 0);
+        graph.link_nodes(a, 0, root, 0)?;
+
+        let mut hierarchy = Hierarchy::new();
+        hierarchy.push_child(a, root)?;
+        hierarchy.push_child(b, root)?;
+        hierarchy.push_child(c, b)?;
+
+        let region = FlatRegion::new(&graph, &hierarchy, root);
+
+        assert!(region.nodes_iter().eq([a, b]));
+        assert_eq!(region.node_count(), 2);
+        assert_eq!(region.port_count(), 3);
+        assert_eq!(region.link_count(), 0);
+
+        assert!(region.all_links(a).eq([]));
+        assert!(region.all_neighbours(a).eq([]));
+
+        Ok(())
     }
 
     #[test]
@@ -159,16 +383,22 @@ mod test {
         let root = graph.add_node(42, 0);
         let a = graph.add_node(1, 2);
         let b = graph.add_node(0, 0);
+        let c = graph.add_node(0, 0);
         graph.link_nodes(a, 0, root, 0)?;
 
         let mut hierarchy = Hierarchy::new();
         hierarchy.push_child(a, root)?;
         hierarchy.push_child(b, root)?;
+        hierarchy.push_child(c, b)?;
 
         let region = Region::new(&graph, &hierarchy, root);
 
-        assert!(region.nodes_iter().eq([a, b]));
-        assert_eq!(region.node_count(), 2);
+        assert!(
+            region.nodes_iter().eq([a, b, c]),
+            "{:?} != [a,b,c]",
+            region.nodes_iter().collect::<Vec<_>>()
+        );
+        assert_eq!(region.node_count(), 3);
         assert_eq!(region.port_count(), 3);
         assert_eq!(region.link_count(), 0);
 


### PR DESCRIPTION
- Adds a `NodeFiltered` adaptor that only expose some nodes of the graph.

- Uses that adaptor to define some `Region` and `FlatRegion` views focused on the children of a node in a hierarchy.
  The code in `region.rs` is mostly delegating all work to the internal `NodeFiltered`, and copied once for each adaptor.