### PR TITLE
Add a `PortMut::swap_nodes` method

### DIFF
--- a/src/multiportgraph.rs
+++ b/src/multiportgraph.rs
@@ -291,6 +291,11 @@ impl PortMut for MultiPortGraph {
         });
     }
 
+    fn swap_nodes(&mut self, a: NodeIndex, b: NodeIndex) {
+        self.graph.swap_nodes(a, b);
+        self.copy_node.swap(a, b);
+    }
+
     fn compact_ports<F>(&mut self, mut rekey: F)
     where
         F: FnMut(PortIndex, PortIndex),

--- a/src/view.rs
+++ b/src/view.rs
@@ -252,6 +252,9 @@ pub trait PortMut: PortView {
     where
         F: FnMut(PortIndex, PortOperation);
 
+    /// Swaps the indices of two nodes.
+    fn swap_nodes(&mut self, a: NodeIndex, b: NodeIndex);
+
     /// Compacts the storage of nodes in the portgraph as much as possible. Note
     /// that node indices won't necessarily be consecutive after this process.
     ///


### PR DESCRIPTION
This may be used to manipulate the order of nodes.

It required converting the free node linked list in `portgraph` into doubly-linked (so moved free entries can be updated).