### PR TITLE
fix: Ignore hierarchy elements that are not in the graph when displaying

### DIFF
--- a/src/dot.rs
+++ b/src/dot.rs
@@ -336,17 +336,20 @@ where
                 dot.push_str(&node_str);
 
                 // Connect the parent to any existing children
-                forest.children(n).for_each(|child| {
-                    dot.push_str(&{
-                        let from_node = n;
-                        let to_node = child;
-                        format!(
-                            "{} -> {}  [style = \"dashed\"] \n",
-                            hier_node_id(from_node),
-                            hier_node_id(to_node),
-                        )
+                forest
+                    .children(n)
+                    .filter(|&c| self.graph.contains_node(c))
+                    .for_each(|child| {
+                        dot.push_str(&{
+                            let from_node = n;
+                            let to_node = child;
+                            format!(
+                                "{} -> {}  [style = \"dashed\"] \n",
+                                hier_node_id(from_node),
+                                hier_node_id(to_node),
+                            )
+                        });
                     });
-                });
             }
         }
     }


### PR DESCRIPTION
This happened when using a filtered graph (e.g. FlatRegion).

![image](https://github.com/CQCL/portgraph/assets/121866228/c866a263-bc6d-432c-b1bb-ca2cd45876ee)
