### PR TITLE
Release v0.7.2

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Unreleased (2023-XX-XX)
+## v0.7.2 (2023-07-31)
 
 ### Added
 


### PR DESCRIPTION
Not sure if this should be `0.8.0` instead, since the toposort update may break type inference, so it requires adding `: Toposort<_>` in some places.