### PR TITLE
ci: Enforce conventional commit formatting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    commit-message:
+      # Use a conventional commit tag
+      prefix: "chore(deps)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,6 +37,8 @@ jobs:
           RUSTDOCFLAGS: "-Dwarnings"
 
   miri:
+    # Not required, we can ignore it for the merge queue check.
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -49,6 +53,8 @@ jobs:
         run: cargo miri test
 
   benches:
+    # Not required, we can ignore it for the merge queue check.
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -66,15 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          #- rust: 1.69.0  # Update once MSRV != stable
-          - rust: stable
-            cache: true
-          - rust: beta
-            cache: true
-          - rust: nightly
-            cache: true
-
+        rust: [1.69, stable, beta, nightly]
     steps:
       - uses: actions/checkout@v3
       - id: toolchain
@@ -84,7 +82,6 @@ jobs:
       - name: Configure default rust toolchain
         run: rustup override set ${{steps.toolchain.outputs.name}}
       - uses: Swatinem/rust-cache@v2
-        if: ${{ matrix.cache }}
         with:
           prefix-key: v0-rust-${{ matrix.rust }}
       - name: Build with no features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
   miri:
     # Not required, we can ignore it for the merge queue check.
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
 
   benches:
     # Not required, we can ignore it for the merge queue check.
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.70, stable, beta, nightly]
+        rust: ['1.70', stable, beta, nightly]
     steps:
       - uses: actions/checkout@v3
       - id: toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.69, stable, beta, nightly]
+        rust: [1.70, stable, beta, nightly]
     steps:
       - uses: actions/checkout@v3
       - id: toolchain

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,9 @@
 name: Check Conventional Commits format
 
 on:
-  pull_request:
+  pull_request_target:
+    branches:
+      - main 
     types:
       - opened
       - edited

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,64 @@
+name: Check Conventional Commits format
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+  merge_group:
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate Conventional Commit PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed (newline-delimited).
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            ci
+            chore
+            revert
+          # Configure which scopes are allowed (newline-delimited).
+          # These are regex patterns auto-wrapped in `^ $`.
+          #scopes: |
+          #  .*
+          # Configure that a scope must always be provided.
+          requireScope: false
+          # Configure which scopes are disallowed in PR titles (newline-delimited).
+          # For instance by setting the value below, `chore(release): ...` (lowercase)
+          # and `ci(e2e,release): ...` (unknown scope) will be rejected.
+          # These are regex patterns auto-wrapped in `^ $`.
+          #disallowScopes: |
+          #  release
+          #  [A-Z]+
+          # Configure additional validation for the subject based on a regex.
+          # This example ensures the subject doesn't start with an uppercase character.
+          #subjectPattern: ^(?![A-Z]).+$
+          # If `subjectPattern` is configured, you can use this property to override
+          # the default error message that is shown when the pattern doesn't match.
+          # The variables `subject` and `title` can be used within the message.
+          #subjectPatternError: |
+          #  The subject "{subject}" found in the pull request title "{title}"
+          #  didn't match the configured pattern. Please ensure that the subject
+          #  doesn't start with an uppercase character.
+          # If the PR contains one of these newline-delimited labels, the
+          # validation is skipped. If you want to rerun the validation when
+          # labels change, you might want to use the `labeled` and `unlabeled`
+          # event triggers in your workflow.
+          ignoreLabels: |
+            ignore-semantic-pull-request

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,7 +10,6 @@ on:
       - synchronize
       - labeled
       - unlabeled
-  merge_group:
 
 permissions:
   pull-requests: read

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,11 +1,13 @@
 name: Check Conventional Commits format
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
       - synchronize
+      - labeled
+      - unlabeled
   merge_group:
 
 permissions:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,6 +10,8 @@ on:
       - synchronize
       - labeled
       - unlabeled
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   pull-requests: read
@@ -18,6 +20,9 @@ jobs:
   main:
     name: Validate Conventional Commit PR title
     runs-on: ubuntu-latest
+    # The action does not support running on merge_group events,
+    # but if the check succeeds in the PR there is no need to check it again.
+    if: github.event_name == 'pull_request_target'
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["data-structure", "graph"]
 categories = ["data-structures"]
 
 edition = "2021"
-rust-version = "1.69"
+rust-version = "1.70"
 
 [lib]
 bench = false

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ This project is licensed under Apache License, Version 2.0 ([LICENSE][] or http:
   [build_status]: https://github.com/CQCL/portgraph/workflows/Continuous%20integration/badge.svg?branch=main
   [crates]: https://img.shields.io/crates/v/portgraph
   [LICENSE]: LICENCE
-  [msrv]: https://img.shields.io/badge/rust-1.69.0%2B-blue.svg?maxAge=3600
+  [msrv]: https://img.shields.io/badge/rust-1.70.0%2B-blue.svg?maxAge=3600
   [RELEASES]: RELEASES.rst


### PR DESCRIPTION
This should let us automate changelogs and releases in the future.