### PR TITLE
feat: Require Clone instead of Copy in ConvexChecker, add `Copy` to filters

### DIFF
--- a/src/algorithms/convex.rs
+++ b/src/algorithms/convex.rs
@@ -27,14 +27,14 @@ pub struct ConvexChecker<G> {
 
 impl<G> ConvexChecker<G>
 where
-    G: LinkView + Copy,
+    G: LinkView + Clone,
 {
     /// Create a new ConvexChecker.
     pub fn new(graph: G) -> Self {
         let inputs = graph
             .nodes_iter()
             .filter(|&n| graph.input_neighbours(n).count() == 0);
-        let topsort: TopoSort<_> = toposort(graph, inputs, Direction::Outgoing);
+        let topsort: TopoSort<_> = toposort(graph.clone(), inputs, Direction::Outgoing);
         let topsort_nodes: Vec<_> = topsort.collect();
         let mut topsort_ind = UnmanagedDenseMap::with_capacity(graph.node_count());
         for (i, &n) in topsort_nodes.iter().enumerate() {
@@ -51,7 +51,7 @@ where
 
     /// The graph on which convexity queries can be made.
     pub fn graph(&self) -> G {
-        self.graph
+        self.graph.clone()
     }
 
     /// Whether the subgraph induced by the node set is convex.

--- a/src/view/filter.rs
+++ b/src/view/filter.rs
@@ -17,14 +17,14 @@ pub type LinkFilter<Ctx> = fn(PortIndex, &Ctx) -> bool;
 /// Both nodes and links can be filtered by providing the filter functions
 /// `node_filter` and `link_filter`.
 ///
-/// As ports always occopy a contiguous interval of indices, they cannot be
+/// As ports always occupy a contiguous interval of indices, they cannot be
 /// filtered out directly. Instead, when `link_filter` filters out a port it
 /// appears as disconnected, effectively remove the link between ports. A link
 /// is removed whenever either of its ports is filtered out.
 ///
 /// For the special case of filtering out nodes only, the type alias
 /// [`NodeFiltered`] is provided, along with [`NodeFiltered::new_node_filtered`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct FilteredGraph<'a, G, FN, FP, Context = ()> {
     graph: &'a G,
     node_filter: FN,
@@ -119,7 +119,7 @@ impl<G, Ctx> FilteredGraph<'_, G, NodeFilter<Ctx>, LinkFilter<Ctx>, Ctx> {
 /// Context used internally for the [`FilteredGraph`] iterators.
 ///
 /// This is a named struct to make the iterator signatures more readable.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct FilteredGraphCtx<'a, G, Ctx> {
     pub(self) graph: &'a G,
     pub(self) node_filter: NodeFilter<Ctx>,


### PR DESCRIPTION
So we can use the convex checker with non-trivial graph references.

I added a `Copy` derive to the graph filters as a drive-by, but it depends on their context being `Copy`.