### PR TITLE
feat: allow non-references in the wrappers

### DIFF
--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -201,7 +201,7 @@ impl Hierarchy {
         }
 
         let Some(parent) = self.get(before).parent else {
-            return Err(AttachError::RootSibling{root: before});
+            return Err(AttachError::RootSibling { root: before });
         };
 
         if !self.cycle_check(node, parent) {
@@ -242,7 +242,7 @@ impl Hierarchy {
         }
 
         let Some(parent) = self.get(after).parent else {
-            return Err(AttachError::RootSibling{root: after});
+            return Err(AttachError::RootSibling { root: after });
         };
 
         if !self.cycle_check(node, parent) {

--- a/src/multiportgraph.rs
+++ b/src/multiportgraph.rs
@@ -478,7 +478,7 @@ impl MultiPortGraph {
         port: PortIndex,
     ) -> Result<(SubportIndex, PortIndex), LinkError> {
         let Some(dir) = self.graph.port_direction(port) else {
-            return Err(LinkError::UnknownPort{port});
+            return Err(LinkError::UnknownPort { port });
         };
         let multiport = *self.multiport.get(port.index());
         let link = self.graph.port_link(port);

--- a/src/portgraph.rs
+++ b/src/portgraph.rs
@@ -389,7 +389,9 @@ impl PortView for PortGraph {
     }
 
     fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize {
-        let Some(node_meta) = self.node_meta_valid(node) else {return 0;};
+        let Some(node_meta) = self.node_meta_valid(node) else {
+            return 0;
+        };
         if Direction::Incoming == direction {
             node_meta.incoming() as usize
         } else {
@@ -558,7 +560,9 @@ impl PortMut for PortGraph {
 
         let new_total = incoming + outgoing;
 
-        let Some(node_meta) = self.node_meta_valid(node) else {return;};
+        let Some(node_meta) = self.node_meta_valid(node) else {
+            return;
+        };
         let old_incoming = node_meta.incoming() as usize;
         let old_outgoing = node_meta.outgoing() as usize;
         let old_capacity = node_meta.capacity();
@@ -648,7 +652,9 @@ impl PortMut for PortGraph {
         self.node_meta.swap(a.index(), b.index());
         // Update the node indices in the ports metadata.
         let mut update_ports = |new_node: NodeIndex, entry: NodeEntry| {
-            let NodeEntry::Node(node_meta) = entry else {return;};
+            let NodeEntry::Node(node_meta) = entry else {
+                return;
+            };
             for dir in Direction::BOTH {
                 for port in node_meta.ports(dir) {
                     self.port_meta[port] = PortEntry::Port(PortMeta::new(new_node, dir));
@@ -822,11 +828,11 @@ impl LinkMut for PortGraph {
         port_b: PortIndex,
     ) -> Result<(Self::LinkEndpoint, Self::LinkEndpoint), LinkError> {
         let Some(meta_a) = self.port_meta_valid(port_a) else {
-            return Err(LinkError::UnknownPort{port: port_a});
+            return Err(LinkError::UnknownPort { port: port_a });
         };
 
         let Some(meta_b) = self.port_meta_valid(port_b) else {
-            return Err(LinkError::UnknownPort{port: port_a});
+            return Err(LinkError::UnknownPort { port: port_a });
         };
 
         if meta_a.direction() == meta_b.direction() {

--- a/src/view.rs
+++ b/src/view.rs
@@ -569,7 +569,7 @@ pub trait LinkMut: LinkView + PortMut {
             for (from, to) in other.all_links(old) {
                 // If the other node has already been inserted, we can link
                 let Some(&other_node) = rekeys.get(&other.port_node(to).unwrap()) else {
-                    continue
+                    continue;
                 };
                 self.link_offsets(
                     new,

--- a/src/view/petgraph.rs
+++ b/src/view/petgraph.rs
@@ -258,17 +258,17 @@ macro_rules! impl_visit_sparse {
 
 impl_petgraph_traits!(PortGraph);
 impl_petgraph_traits!(MultiPortGraph);
-impl_petgraph_traits!(NodeFiltered<'a, G, NodeFilter<Ctx>, Ctx>, ['a, G, Ctx]
+impl_petgraph_traits!(NodeFiltered<G, NodeFilter<Ctx>, Ctx>, ['a, G, Ctx]
     where
-        G: LinkView,
+        G: LinkView + Clone,
         <G as LinkView>::LinkEndpoint: Eq
 );
 
 impl_visit_dense!(PortGraph);
 impl_visit_dense!(MultiPortGraph);
-impl_visit_sparse!(NodeFiltered<'a, G, NodeFilter<Ctx>, Ctx>, ['a, G, Ctx]
+impl_visit_sparse!(NodeFiltered<G, NodeFilter<Ctx>, Ctx>, ['a, G, Ctx]
     where
-        G: LinkView,
+        G: LinkView + Clone,
         <G as LinkView>::LinkEndpoint: Eq
 );
 

--- a/src/view/region.rs
+++ b/src/view/region.rs
@@ -16,11 +16,14 @@ type RegionCallback<'g> = fn(NodeIndex, &RegionContext<'g>) -> bool;
 ///
 /// [`Region`] does not implement `Sync` as it uses a [`RefCell`] to cache the
 /// node filtering.
-pub type Region<'g, G> = NodeFiltered<'g, G, RegionCallback<'g>, RegionContext<'g>>;
+pub type Region<'g, G> = NodeFiltered<G, RegionCallback<'g>, RegionContext<'g>>;
 
-impl<'a, G> Region<'a, G> {
+impl<'a, G> Region<'a, G>
+where
+    G: Clone,
+{
     /// Create a new region view including all the descendants of the root node.
-    pub fn new_region(graph: &'a G, hierarchy: &'a Hierarchy, root: NodeIndex) -> Self {
+    pub fn new_region(graph: G, hierarchy: &'a Hierarchy, root: NodeIndex) -> Self {
         let region_filter: RegionCallback<'a> =
             |node, context| node == context.root() || context.is_descendant(node);
         Self::new_node_filtered(graph, region_filter, RegionContext::new(hierarchy, root))
@@ -92,11 +95,14 @@ type FlatRegionCallback<'g> = fn(NodeIndex, &FlatRegionContext<'g>) -> bool;
 /// View of a portgraph containing only a root node and its direct children in a [`Hierarchy`].
 ///
 /// For a view of all descendants, see [`Region`].
-pub type FlatRegion<'g, G> = NodeFiltered<'g, G, FlatRegionCallback<'g>, FlatRegionContext<'g>>;
+pub type FlatRegion<'g, G> = NodeFiltered<G, FlatRegionCallback<'g>, FlatRegionContext<'g>>;
 
-impl<'a, G> FlatRegion<'a, G> {
+impl<'a, G> FlatRegion<'a, G>
+where
+    G: Clone,
+{
     /// Create a new region view including all the descendants of the root node.
-    pub fn new_flat_region(graph: &'a G, hierarchy: &'a Hierarchy, root: NodeIndex) -> Self {
+    pub fn new_flat_region(graph: G, hierarchy: &'a Hierarchy, root: NodeIndex) -> Self {
         let region_filter: FlatRegionCallback<'a> = |node, context| {
             let (hierarchy, root) = context;
             node == *root || hierarchy.parent(node) == Some(*root)


### PR DESCRIPTION
Follow-up for #104.

Instead of requiring `&G` in the graph filters we just use `G: Clone`, so other things like `G: AsRef<PortGraph>` can be used as base.