### PR TITLE
ci: avoid running unnecessary jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
   miri:
     # Not required, we can ignore it for the merge queue check.
-    if: github.event_name == 'pull_request'
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
 
   benches:
     # Not required, we can ignore it for the merge queue check.
-    if: github.event_name == 'pull_request'
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -73,6 +73,18 @@ jobs:
     strategy:
       matrix:
         rust: ['1.70', stable, beta, nightly]
+        # workaround to ignore non-stable tests when running the merge queue checks
+        # see: https://github.community/t/how-to-conditionally-include-exclude-items-in-matrix-eg-based-on-branch/16853/6
+        isMerge:
+            - ${{ github.event_name == 'merge_group' }}
+        exclude:
+          - rust: '1.70'
+            isMerge: true
+          - rust: beta
+            isMerge: true
+          - rust: nightly
+            isMerge: true
+    name: tests (Rust ${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v3
       - id: toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,10 @@ jobs:
         with:
           prefix-key: v0-rust-${{ matrix.rust }}
       - name: Build with no features
-        run: cargo build --verbose --no-default-features
-      - name: Build with all features
-        run: cargo build --verbose --all-features
+        run: cargo test --verbose --no-default-features --no-run
       - name: Tests with no features
         run: cargo test --verbose --no-default-features
+      - name: Build with all features
+        run: cargo test --verbose --all-features --no-run
       - name: Tests with all features
         run: cargo test --verbose --all-features


### PR DESCRIPTION
#cisheddingfriday

- skips all non-required test jobs (the ones not for rust `stable`) when in the merge queue.
- Avoids compiling the tests twice on each job by tweaking the "Build with * features" step commands.

~The tests will fail until #106 is merged.~ (done)