### PR TITLE
chore(deps)!: update pyo3 requirement from 0.19 to 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,9 @@ path = "src/lib.rs"
 
 [dependencies]
 thiserror = "1.0.28"
-pyo3 = { version = "0.19", optional = true, features = [
-    "multiple-pymethods",
-] }
+pyo3 = { version = "0.20", optional = true, features = ["multiple-pymethods"] }
 bitvec = "1.0.1"
-serde = { version = "1.0.152", features = ["derive"], optional = true}
+serde = { version = "1.0.152", features = ["derive"], optional = true }
 proptest = { version = "1.1.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 petgraph = { version = "0.6.3", optional = true }


### PR DESCRIPTION
BREAKING CHANGE: Updated the pyo3 dependency major version. All transitive dependencies to that crate must use the same version due to linking restrictions. See [links](https://doc.rust-lang.org/cargo/reference/resolver.html#links).