### PR TITLE
feat: Simpler convex checker, no longer requires `&mut`

### DIFF
--- a/benches/benchmarks/convex.rs
+++ b/benches/benchmarks/convex.rs
@@ -1,4 +1,5 @@
 use criterion::{black_box, criterion_group, AxisScale, BenchmarkId, Criterion, PlotConfiguration};
+use itertools::Itertools;
 use portgraph::{algorithms::ConvexChecker, PortView};
 
 use super::generators::make_two_track_dag;
@@ -22,17 +23,36 @@ fn bench_convex_construction(c: &mut Criterion) {
 
 /// We benchmark the worst case scenario, where the "subgraph" is the
 /// entire graph itself.
-fn bench_convex(c: &mut Criterion) {
-    let mut g = c.benchmark_group("Runtime convexity check");
+fn bench_convex_full(c: &mut Criterion) {
+    let mut g = c.benchmark_group("Runtime convexity check. Full graph.");
     g.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
 
     for size in [100, 1_000, 10_000] {
         let graph = make_two_track_dag(size);
         let mut checker = ConvexChecker::new(&graph);
         g.bench_with_input(
-            BenchmarkId::new("check_convexity", size),
+            BenchmarkId::new("check_convexity_full", size),
             &size,
             |b, _size| b.iter(|| black_box(checker.is_node_convex(graph.nodes_iter()))),
+        );
+    }
+    g.finish();
+}
+
+/// We benchmark the an scenario where the size of the "subgraph" is sub-linear on the size of the graph.
+fn bench_convex_sparse(c: &mut Criterion) {
+    let mut g = c.benchmark_group("Runtime convexity check. Sparse subgraph on an n^2 size graph.");
+    g.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
+
+    for size in [100usize, 1_000, 5_000] {
+        let graph_size = size.pow(2);
+        let graph = make_two_track_dag(graph_size);
+        let mut checker = ConvexChecker::new(&graph);
+        let nodes = graph.nodes_iter().step_by(graph_size / size).collect_vec();
+        g.bench_with_input(
+            BenchmarkId::new("check_convexity_sparse", size),
+            &size,
+            |b, _size| b.iter(|| black_box(checker.is_node_convex(nodes.iter().copied()))),
         );
     }
     g.finish();
@@ -42,6 +62,7 @@ criterion_group! {
     name = benches;
     config = Criterion::default();
     targets =
-        bench_convex,
+        bench_convex_full,
+        bench_convex_sparse,
         bench_convex_construction
 }

--- a/benches/benchmarks/convex.rs
+++ b/benches/benchmarks/convex.rs
@@ -29,7 +29,7 @@ fn bench_convex_full(c: &mut Criterion) {
 
     for size in [100, 1_000, 10_000] {
         let graph = make_two_track_dag(size);
-        let mut checker = ConvexChecker::new(&graph);
+        let checker = ConvexChecker::new(&graph);
         g.bench_with_input(
             BenchmarkId::new("check_convexity_full", size),
             &size,
@@ -47,7 +47,7 @@ fn bench_convex_sparse(c: &mut Criterion) {
     for size in [100usize, 1_000, 5_000] {
         let graph_size = size.pow(2);
         let graph = make_two_track_dag(graph_size);
-        let mut checker = ConvexChecker::new(&graph);
+        let checker = ConvexChecker::new(&graph);
         let nodes = graph.nodes_iter().step_by(graph_size / size).collect_vec();
         g.bench_with_input(
             BenchmarkId::new("check_convexity_sparse", size),

--- a/src/algorithms/convex.rs
+++ b/src/algorithms/convex.rs
@@ -70,7 +70,7 @@ where
     /// that are in the interval between the first and last node of the subgraph
     /// in some topological order. In the worst case this will traverse every
     /// node in the graph and can be improved on in the future.
-    pub fn is_node_convex(&mut self, nodes: impl IntoIterator<Item = NodeIndex>) -> bool {
+    pub fn is_node_convex(&self, nodes: impl IntoIterator<Item = NodeIndex>) -> bool {
         // The nodes in the subgraph, in topological order.
         let nodes: BTreeSet<_> = nodes.into_iter().map(|n| self.topsort_ind[n]).collect();
         if nodes.is_empty() {
@@ -96,7 +96,9 @@ where
             if other_nodes.is_empty() || node_iter.peek() < other_nodes.first() {
                 let current = node_iter.next().unwrap();
                 let current_node = self.topsort_nodes[current];
-                for neighbour in self.graph.output_neighbours(current_node)
+                for neighbour in self
+                    .graph
+                    .output_neighbours(current_node)
                     .map(|n| self.topsort_ind[n])
                     .filter(|ind| node_range.contains(ind))
                 {
@@ -107,7 +109,9 @@ where
             } else {
                 let current = other_nodes.pop_first().unwrap();
                 let current_node = self.topsort_nodes[current];
-                for neighbour in self.graph.output_neighbours(current_node)
+                for neighbour in self
+                    .graph
+                    .output_neighbours(current_node)
                     .map(|n| self.topsort_ind[n])
                     .filter(|ind| node_range.contains(ind))
                 {
@@ -147,7 +151,7 @@ where
     /// Any edge between two nodes of the subgraph that does not have an explicit
     /// input or output port is considered within the subgraph.
     pub fn is_convex(
-        &mut self,
+        &self,
         nodes: impl IntoIterator<Item = NodeIndex>,
         inputs: impl IntoIterator<Item = PortIndex>,
         outputs: impl IntoIterator<Item = PortIndex>,
@@ -197,7 +201,7 @@ mod tests {
     #[test]
     fn induced_convexity_test() {
         let (g, [i1, i2, i3, n1, n2, o1, o2]) = graph();
-        let mut checker = ConvexChecker::new(&g);
+        let checker = ConvexChecker::new(&g);
 
         assert!(checker.is_node_convex([i1, i2, i3]));
         assert!(checker.is_node_convex([i1, n2]));
@@ -212,7 +216,7 @@ mod tests {
     #[test]
     fn edge_convexity_test() {
         let (g, [i1, i2, _, n1, n2, _, o2]) = graph();
-        let mut checker = ConvexChecker::new(&g);
+        let checker = ConvexChecker::new(&g);
 
         assert!(checker.is_convex(
             [i1, n2],
@@ -245,7 +249,7 @@ mod tests {
     fn dangling_input() {
         let mut g = PortGraph::new();
         let n = g.add_node(1, 1);
-        let mut checker = ConvexChecker::new(&g);
+        let checker = ConvexChecker::new(&g);
         assert!(checker.is_node_convex([n]));
     }
 
@@ -254,7 +258,7 @@ mod tests {
         let mut g = PortGraph::new();
         let n = g.add_node(1, 1);
         g.add_node(1, 1);
-        let mut checker = ConvexChecker::new(&g);
+        let checker = ConvexChecker::new(&g);
         assert!(checker.is_node_convex([n]));
     }
 }

--- a/src/algorithms/convex.rs
+++ b/src/algorithms/convex.rs
@@ -14,14 +14,14 @@ use crate::{Direction, LinkView, NodeIndex, PortIndex, SecondaryMap, UnmanagedDe
 
 use super::TopoSort;
 
-/// A pre-computed datastructure for fast convexity checking.
+/// A pre-computed data structure for fast convexity checking.
 pub struct ConvexChecker<G> {
     graph: G,
     // The nodes in topological order
     topsort_nodes: Vec<NodeIndex>,
     // The index of a node in the topological order (the inverse of topsort_nodes)
     topsort_ind: UnmanagedDenseMap<NodeIndex, usize>,
-    // A temporary datastructure used during `is_convex`
+    // A temporary data structure used during `is_convex`
     causal: CausalVec,
 }
 
@@ -60,7 +60,7 @@ where
     /// past and in the future of another node of the subgraph.
     ///
     /// This function requires mutable access to `self` because it uses a
-    /// temporary datastructure within the object.
+    /// temporary data structure within the object.
     ///
     /// ## Arguments
     ///
@@ -111,7 +111,7 @@ where
     /// Whether a subgraph is convex.
     ///
     /// A subgraph is convex if there is no path between two nodes of the
-    /// sugraph that has an edge outside of the subgraph.
+    /// subgraph that has an edge outside of the subgraph.
     ///
     /// Equivalently, we check the following two conditions:
     ///  - There is no node that is both in the past and in the future of
@@ -119,7 +119,7 @@ where
     ///  - There is no edge from an output port to an input port.
     ///
     /// This function requires mutable access to `self` because it uses a
-    /// temporary datastructure within the object.
+    /// temporary data structure within the object.
     ///
     /// ## Arguments
     ///

--- a/src/view/subgraph.rs
+++ b/src/view/subgraph.rs
@@ -96,12 +96,12 @@ where
 
     /// Whether the subgraph is convex.
     pub fn is_convex(&self) -> bool {
-        let mut checker = ConvexChecker::new(self.graph());
-        self.is_convex_with_checker(&mut checker)
+        let checker = ConvexChecker::new(self.graph());
+        self.is_convex_with_checker(&checker)
     }
 
     /// Whether the subgraph is convex, using a pre-existing checker.
-    pub fn is_convex_with_checker(&self, checker: &mut ConvexChecker<G>) -> bool {
+    pub fn is_convex_with_checker(&self, checker: &ConvexChecker<G>) -> bool {
         checker.is_convex(
             self.nodes_iter(),
             self.context().inputs.iter().copied(),


### PR DESCRIPTION
ConvexChecker now uses the pre-computed node toposort to compute traverse the subgraph nodes and their causal future in order.

This should end up processing less nodes than the previous version, and let us avoid the temporary datastructure that required `&mut checker` all throughout the API.

I added some simple benchmarks, but unfortunately they are not the best at showing the improvements in this refactor (we end up traversing most of the nodes anyway).
In more real tests on `tket2` I saw small improvements, but nothing to write home about.