### PR TITLE
fix: Link and neighbour iterators counting self-loops twice

### DIFF
--- a/.github/pre-commit
+++ b/.github/pre-commit
@@ -9,10 +9,22 @@ if [[ "${IGNORE_RUSTHOOKS:=0}" -ne 0 ]]; then
     exit 0
 fi
 
-if ! cargo fmt -- --check
+if ! cargo fmt --all -- --check
 then
     echo "There are some code style issues."
     echo "Run cargo fmt first."
+    exit 1
+fi
+
+if ! cargo check --all --all-features --workspace
+then
+    echo "There are some compilation warnings."
+    exit 1
+fi
+
+if ! cargo test --all-features --workspace
+then
+    echo "There are some test issues."
     exit 1
 fi
 
@@ -22,9 +34,10 @@ then
     exit 1
 fi
 
-if ! cargo test --all-features
+RUSTDOCFLAGS="-Dwarnings"
+if ! cargo doc --no-deps --all-features --workspace
 then
-    echo "There are some test issues."
+    echo "There are some clippy issues."
     exit 1
 fi
 

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ test:
 
 # Auto-fix all clippy warnings
 fix:
-    cargo clippy --all-targets --all-features --workspace --fix --allow-staged
+    cargo clippy --all-targets --all-features --workspace --fix --allow-staged --allow-dirty
 
 # Run the pre-commit checks
 check:

--- a/src/portgraph.rs
+++ b/src/portgraph.rs
@@ -304,6 +304,14 @@ impl PortGraph {
         self.port_count -= node_meta.incoming() as usize + node_meta.outgoing() as usize;
         self.port_count += incoming + outgoing;
     }
+
+    /// Returns the range of outgoing port indices for a given node.
+    pub(crate) fn node_outgoing_ports(&self, node: NodeIndex) -> Range<usize> {
+        match self.node_meta_valid(node) {
+            Some(node_meta) => node_meta.outgoing_ports(),
+            None => 0..0,
+        }
+    }
 }
 
 impl PortView for PortGraph {


### PR DESCRIPTION
The `all_links` iterator for both `Portgraph` and `Multiportgraph`, and `all_neighbours` for the latter yielded self-loops twice.

This in turn caused `insert_graph` to try inserting repeated links, as reported in #130. 

This PR fixes the error and adds tests for that.

Fixes #130.

drive-by: Add missing checks in the pre-commit hook.