### PR TITLE
feat: Add PortOffset::opposite

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,3 +396,17 @@ impl std::fmt::Debug for PortOffset {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_opposite() {
+        let incoming = PortOffset::Incoming(5);
+        let outgoing = PortOffset::Outgoing(5);
+
+        assert_eq!(incoming.opposite(), outgoing);
+        assert_eq!(outgoing.opposite(), incoming);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,6 +368,18 @@ impl PortOffset {
             PortOffset::Outgoing(offset) => offset as usize,
         }
     }
+
+    /// Returns the opposite port offset.
+    ///
+    /// This maps `PortOffset::Incoming(x)` to `PortOffset::Outgoing(x)` and
+    /// vice versa.
+    #[inline(always)]
+    pub fn opposite(&self) -> Self {
+        match *self {
+            PortOffset::Incoming(idx) => PortOffset::Outgoing(idx),
+            PortOffset::Outgoing(idx) => PortOffset::Incoming(idx),
+        }
+    }
 }
 
 impl Default for PortOffset {


### PR DESCRIPTION
I would find such a function a useful, straight-forward addition to the `PortOffset` API.