### PR TITLE
fix: Intergraph edges in mermaid rendering

### DIFF
--- a/benches/bench_main.rs
+++ b/benches/bench_main.rs
@@ -6,6 +6,7 @@ use criterion::criterion_main;
 criterion_main! {
     benchmarks::hierarchy::benches,
     benchmarks::portgraph::benches,
+    benchmarks::render::benches,
     benchmarks::toposort::benches,
     benchmarks::convex::benches,
 }

--- a/benches/benchmarks/mod.rs
+++ b/benches/benchmarks/mod.rs
@@ -3,4 +3,5 @@ pub mod generators;
 pub mod convex;
 pub mod hierarchy;
 pub mod portgraph;
+pub mod render;
 pub mod toposort;

--- a/benches/benchmarks/render.rs
+++ b/benches/benchmarks/render.rs
@@ -1,0 +1,60 @@
+//! Benchmarks for the graph renderers.
+
+use criterion::{black_box, criterion_group, AxisScale, BenchmarkId, Criterion, PlotConfiguration};
+use portgraph::render::{DotFormat, MermaidFormat};
+
+use super::generators::{make_hierarchy, make_two_track_dag, make_weights};
+
+fn bench_render_mermaid(c: &mut Criterion) {
+    let mut g = c.benchmark_group("Mermaid rendering. Graph with hierarchy.");
+    g.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
+
+    for size in [100, 1_000, 10_000] {
+        let graph = make_two_track_dag(size);
+        let hierarchy = make_hierarchy(&graph);
+        let weights = make_weights(&graph);
+        g.bench_with_input(BenchmarkId::new("hierarchy", size), &size, |b, _size| {
+            b.iter(|| {
+                black_box(
+                    graph
+                        .mermaid_format()
+                        .with_hierarchy(&hierarchy)
+                        .with_weights(&weights)
+                        .finish(),
+                )
+            })
+        });
+    }
+    g.finish();
+}
+
+fn bench_render_dot(c: &mut Criterion) {
+    let mut g = c.benchmark_group("Dot rendering. Graph with tree hierarchy.");
+    g.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
+
+    for size in [100, 1_000, 10_000] {
+        let graph = make_two_track_dag(size);
+        let hierarchy = make_hierarchy(&graph);
+        let weights = make_weights(&graph);
+        g.bench_with_input(BenchmarkId::new("hierarchy", size), &size, |b, _size| {
+            b.iter(|| {
+                black_box(
+                    graph
+                        .dot_format()
+                        .with_hierarchy(&hierarchy)
+                        .with_weights(&weights)
+                        .finish(),
+                )
+            })
+        });
+    }
+    g.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets =
+        bench_render_mermaid,
+        bench_render_dot,
+}

--- a/src/snapshots/portgraph__render__test__flat__mermaid.snap
+++ b/src/snapshots/portgraph__render__test__flat__mermaid.snap
@@ -3,8 +3,8 @@ source: src/render.rs
 expression: mermaid
 ---
 graph LR
+    2[2]
+    1[1]
     0[0]
     0-->1
     0-->2
-    1[1]
-    2[2]

--- a/src/snapshots/portgraph__render__test__hierarchy__mermaid.snap
+++ b/src/snapshots/portgraph__render__test__hierarchy__mermaid.snap
@@ -6,6 +6,6 @@ graph LR
     subgraph 0 [0]
         direction LR
         1[1]
-        1-->2
         2[2]
+        1-->2
     end

--- a/src/snapshots/portgraph__render__test__hierarchy_interregional__mermaid.snap
+++ b/src/snapshots/portgraph__render__test__hierarchy_interregional__mermaid.snap
@@ -8,11 +8,11 @@ graph LR
         subgraph 1 [1]
             direction LR
             3[3]
-            3-->4
         end
-        1-->2
         subgraph 2 [2]
             direction LR
             4[4]
         end
+        1-->2
+        3-->4
     end

--- a/src/snapshots/portgraph__render__test__weighted__mermaid.snap
+++ b/src/snapshots/portgraph__render__test__weighted__mermaid.snap
@@ -3,8 +3,8 @@ source: src/render.rs
 expression: mermaid
 ---
 graph LR
+    2["node3"]
+    1["node2"]
     0["node1"]
     0-->1
     0-->2
-    1["node2"]
-    2["node3"]


### PR DESCRIPTION
Defines intergraph edges on the parent region, so mermaid renders them correctly.

This required a lowest-common-ancestor implementation for the hierarchy. See #138.
I replaced the recursive DFS with a stack-based one that reuses the structures when exploring multiple trees.

I also added some benchmarks for both rendering algorithms.

This closes https://github.com/CQCL/hugr/issues/1197