### PR TITLE
feat!: Use RPITIT for graph traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ proptest = { version = "1.1.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 petgraph = { version = "0.6.3", optional = true }
 delegate = "0.13.0"
-context-iterators = "0.2.0"
 itertools = "0.13.0"
 
 [features]

--- a/benches/benchmarks/portgraph.rs
+++ b/benches/benchmarks/portgraph.rs
@@ -5,7 +5,6 @@ use super::generators::*;
 use criterion::{
     black_box, criterion_group, AxisScale, BatchSize, BenchmarkId, Criterion, PlotConfiguration,
 };
-use itertools::Itertools;
 use portgraph::{PortGraph, PortMut, PortView};
 
 /// Remove one every five nodes from the graph.
@@ -35,13 +34,7 @@ fn remove_all_unordered(graph: &mut PortGraph) {
 
 /// Adds or removes one port from an arbitrary node, `amount` times.
 fn resize_ports(graph: &mut PortGraph, amount: usize) {
-    let nodes = graph
-        .nodes_iter()
-        .collect_vec()
-        .into_iter()
-        .cycle()
-        .take(amount)
-        .collect::<Vec<_>>();
+    let nodes = graph.nodes_iter().cycle().take(amount).collect::<Vec<_>>();
     for (i, node) in nodes.iter().copied().enumerate() {
         let mut inputs = graph.num_inputs(node);
         let mut outputs = graph.num_outputs(node);

--- a/benches/benchmarks/portgraph.rs
+++ b/benches/benchmarks/portgraph.rs
@@ -5,6 +5,7 @@ use super::generators::*;
 use criterion::{
     black_box, criterion_group, AxisScale, BatchSize, BenchmarkId, Criterion, PlotConfiguration,
 };
+use itertools::Itertools;
 use portgraph::{PortGraph, PortMut, PortView};
 
 /// Remove one every five nodes from the graph.
@@ -27,13 +28,20 @@ fn remove_all_unordered(graph: &mut PortGraph) {
     }
     // Remove all remaining nodes
     while graph.node_count() > 0 {
-        graph.remove_node(graph.nodes_iter().next().unwrap());
+        let next = graph.nodes_iter().next().unwrap();
+        graph.remove_node(next);
     }
 }
 
 /// Adds or removes one port from an arbitrary node, `amount` times.
 fn resize_ports(graph: &mut PortGraph, amount: usize) {
-    let nodes = graph.nodes_iter().cycle().take(amount).collect::<Vec<_>>();
+    let nodes = graph
+        .nodes_iter()
+        .collect_vec()
+        .into_iter()
+        .cycle()
+        .take(amount)
+        .collect::<Vec<_>>();
     for (i, node) in nodes.iter().copied().enumerate() {
         let mut inputs = graph.num_inputs(node);
         let mut outputs = graph.num_outputs(node);

--- a/src/algorithms/post_order.rs
+++ b/src/algorithms/post_order.rs
@@ -213,7 +213,7 @@ impl<'graph> Iterator for PostOrder<'graph> {
             if !self.visited.replace(next.index(), true) {
                 // The node is visited for the first time. We leave the node on the stack and push
                 // all of its neighbours in the traversal direction.
-                for port in self.graph.ports(next, self.direction).rev() {
+                for port in self.graph._ports(next, self.direction).rev() {
                     if self.ignore_port(next, port) {
                         continue;
                     }

--- a/src/multiportgraph.rs
+++ b/src/multiportgraph.rs
@@ -260,57 +260,26 @@ impl LinkView for MultiPortGraph {
     type LinkEndpoint = SubportIndex;
 
     #[inline]
-    fn get_connections(
-        &self,
-        from: NodeIndex,
-        to: NodeIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
-        self._get_connections(from, to)
-    }
-
-    #[inline]
-    fn port_links(
-        &self,
-        port: PortIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
-        self._port_links(port)
-    }
-
-    #[inline]
-    fn links(
-        &self,
-        node: NodeIndex,
-        direction: Direction,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
-        self._links(node, direction)
-    }
-
-    #[inline]
-    fn all_links(
-        &self,
-        node: NodeIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
-        self._all_links(node)
-    }
-
-    #[inline]
-    fn neighbours(
-        &self,
-        node: NodeIndex,
-        direction: Direction,
-    ) -> impl Iterator<Item = NodeIndex> + Clone {
-        self._neighbours(node, direction)
-    }
-
-    #[inline]
-    fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + Clone {
-        self._all_neighbours(node)
-    }
-
-    #[inline]
     fn link_count(&self) -> usize {
         // Do not count the links between copy nodes and their main nodes.
         self.graph.link_count() - self.copy_node_count
+    }
+
+    delegate! {
+        to self {
+            #[call(_get_connections)]
+            fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
+            #[call(_port_links)]
+            fn port_links(&self, port: PortIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
+            #[call(_links)]
+            fn links(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
+            #[call(_all_links)]
+            fn all_links(&self, node: NodeIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
+            #[call(_neighbours)]
+            fn neighbours(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = NodeIndex> + Clone;
+            #[call(_all_neighbours)]
+            fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + Clone;
+        }
     }
 }
 
@@ -346,18 +315,13 @@ impl MultiView for MultiPortGraph {
         self.get_subport_from_index(link)
     }
 
-    #[inline]
-    fn subports(
-        &self,
-        node: NodeIndex,
-        direction: Direction,
-    ) -> impl Iterator<Item = SubportIndex> + Clone {
-        self._subports(node, direction)
-    }
-
-    #[inline]
-    fn all_subports(&self, node: NodeIndex) -> impl Iterator<Item = SubportIndex> + Clone {
-        self._all_subports(node)
+    delegate! {
+        to self {
+            #[call(_subports)]
+            fn subports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = SubportIndex> + Clone;
+            #[call(_all_subports)]
+            fn all_subports(&self, node: NodeIndex) -> impl Iterator<Item = SubportIndex> + Clone;
+        }
     }
 }
 

--- a/src/multiportgraph.rs
+++ b/src/multiportgraph.rs
@@ -5,12 +5,13 @@ mod iter;
 pub use self::iter::{
     Neighbours, NodeConnections, NodeLinks, NodeSubports, Nodes, PortLinks, Ports,
 };
-use crate::portgraph::{NodePortOffsets, NodePorts, PortOperation};
+use crate::portgraph::PortOperation;
 use crate::view::{LinkMut, MultiMut, MultiView, PortMut};
 use crate::{
     Direction, LinkError, LinkView, NodeIndex, PortGraph, PortIndex, PortOffset, PortView,
     SecondaryMap,
 };
+use delegate::delegate;
 
 use bitvec::vec::BitVec;
 
@@ -97,77 +98,6 @@ impl MultiPortGraph {
 }
 
 impl PortView for MultiPortGraph {
-    type Nodes<'a> = Nodes<'a>
-    where
-        Self: 'a;
-
-    type Ports<'a> = Ports<'a>
-    where
-        Self: 'a;
-
-    type NodePorts<'a> = NodePorts
-    where
-        Self: 'a;
-
-    type NodePortOffsets<'a> = NodePortOffsets
-    where
-        Self: 'a;
-
-    #[inline]
-    fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction> {
-        self.graph.port_direction(port.into())
-    }
-
-    #[inline]
-    fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex> {
-        self.graph.port_node(port.into())
-    }
-
-    #[inline]
-    fn port_offset(&self, port: impl Into<PortIndex>) -> Option<PortOffset> {
-        self.graph.port_offset(port.into())
-    }
-
-    #[inline]
-    fn port_index(&self, node: NodeIndex, offset: PortOffset) -> Option<PortIndex> {
-        self.graph.port_index(node, offset)
-    }
-
-    #[inline]
-    fn ports(&self, node: NodeIndex, direction: Direction) -> Self::NodePorts<'_> {
-        self.graph.ports(node, direction)
-    }
-
-    #[inline]
-    fn all_ports(&self, node: NodeIndex) -> Self::NodePorts<'_> {
-        self.graph.all_ports(node)
-    }
-
-    #[inline]
-    fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex> {
-        self.graph.input(node, offset)
-    }
-
-    #[inline]
-    fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex> {
-        self.graph.output(node, offset)
-    }
-
-    #[inline]
-    fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize {
-        self.graph.num_ports(node, direction)
-    }
-
-    #[inline]
-    fn port_offsets(&self, node: NodeIndex, direction: Direction) -> Self::NodePortOffsets<'_> {
-        self.graph.port_offsets(node, direction)
-    }
-
-    #[inline]
-    fn all_port_offsets(&self, node: NodeIndex) -> Self::NodePortOffsets<'_> {
-        self.graph.all_port_offsets(node)
-    }
-
     #[inline]
     fn contains_node(&self, node: NodeIndex) -> bool {
         self.graph.contains_node(node) && !self.copy_node.get(node)
@@ -197,18 +127,19 @@ impl PortView for MultiPortGraph {
         // addition to all the subports.
         self.graph.port_count() - self.subport_count - self.copy_node_count
     }
+
     #[inline]
-    fn nodes_iter(&self) -> Self::Nodes<'_> {
+    fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex> {
         self::iter::Nodes {
             multigraph: self,
-            iter: self.graph.nodes_iter(),
+            iter: self.graph._nodes_iter(),
             len: self.node_count(),
         }
     }
 
     #[inline]
-    fn ports_iter(&self) -> Self::Ports<'_> {
-        Ports::new(self, self.graph.ports_iter())
+    fn ports_iter(&self) -> impl Iterator<Item = PortIndex> {
+        Ports::new(self, self.graph._ports_iter())
     }
 
     #[inline]
@@ -222,9 +153,21 @@ impl PortView for MultiPortGraph {
         self.graph.port_capacity() - self.subport_count - self.copy_node_count
     }
 
-    #[inline]
-    fn node_port_capacity(&self, node: NodeIndex) -> usize {
-        self.graph.node_port_capacity(node)
+    delegate! {
+        to (self.graph) {
+            fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction>;
+            fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
+            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<PortOffset>;
+            fn port_index(&self, node: NodeIndex, offset: PortOffset) -> Option<PortIndex>;
+            fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex>;
+            fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex>;
+            fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
+            fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
+            fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset>;
+            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset>;
+            fn node_port_capacity(&self, node: NodeIndex) -> usize;
+        }
     }
 }
 
@@ -236,7 +179,7 @@ impl PortMut for MultiPortGraph {
 
     fn remove_node(&mut self, node: NodeIndex) {
         debug_assert!(!self.copy_node.get(node));
-        for port in self.graph.all_ports(node) {
+        for port in self.graph._all_ports(node) {
             if *self.multiport.get(port) {
                 self.unlink_port(port);
             }
@@ -316,51 +259,48 @@ impl PortMut for MultiPortGraph {
 impl LinkView for MultiPortGraph {
     type LinkEndpoint = SubportIndex;
 
-    type Neighbours<'a> = Neighbours<'a>
-    where
-        Self: 'a;
-
-    type NodeConnections<'a> = NodeConnections<'a>
-    where
-        Self: 'a;
-
-    type NodeLinks<'a> = NodeLinks<'a>
-    where
-        Self: 'a;
-
-    type PortLinks<'a> = PortLinks<'a>
-    where
-        Self: 'a;
-
     #[inline]
-    fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> Self::NodeConnections<'_> {
-        NodeConnections::new(self, to, self.output_links(from))
+    fn get_connections(
+        &self,
+        from: NodeIndex,
+        to: NodeIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+        self._get_connections(from, to)
     }
 
     #[inline]
-    fn port_links(&self, port: PortIndex) -> Self::PortLinks<'_> {
-        PortLinks::new(self, port)
+    fn port_links(
+        &self,
+        port: PortIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+        self._port_links(port)
     }
 
     #[inline]
-    fn links(&self, node: NodeIndex, direction: Direction) -> Self::NodeLinks<'_> {
-        NodeLinks::new(self, self.ports(node, direction), 0..0)
+    fn links(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+        self._links(node, direction)
     }
 
     #[inline]
-    fn all_links(&self, node: NodeIndex) -> Self::NodeLinks<'_> {
-        let output_ports = self.graph.node_outgoing_ports(node);
-        NodeLinks::new(self, self.all_ports(node), output_ports)
+    fn all_links(
+        &self,
+        node: NodeIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+        self._all_links(node)
     }
 
     #[inline]
-    fn neighbours(&self, node: NodeIndex, direction: Direction) -> Self::Neighbours<'_> {
-        Neighbours::new(self, self.subports(node, direction), node, false)
+    fn neighbours(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = NodeIndex> {
+        self._neighbours(node, direction)
     }
 
     #[inline]
-    fn all_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_> {
-        Neighbours::new(self, self.all_subports(node), node, true)
+    fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> {
+        self._all_neighbours(node)
     }
 
     #[inline]
@@ -396,10 +336,6 @@ impl LinkMut for MultiPortGraph {
 }
 
 impl MultiView for MultiPortGraph {
-    type NodeSubports<'a> = NodeSubports<'a>
-    where
-        Self: 'a;
-
     fn subport_link(&self, subport: SubportIndex) -> Option<SubportIndex> {
         let subport_index = self.get_subport_index(subport)?;
         let link = self.graph.port_link(subport_index)?;
@@ -407,13 +343,17 @@ impl MultiView for MultiPortGraph {
     }
 
     #[inline]
-    fn subports(&self, node: NodeIndex, direction: Direction) -> Self::NodeSubports<'_> {
-        NodeSubports::new(self, self.graph.ports(node, direction))
+    fn subports(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = SubportIndex> {
+        self._subports(node, direction)
     }
 
     #[inline]
-    fn all_subports(&self, node: NodeIndex) -> Self::NodeSubports<'_> {
-        NodeSubports::new(self, self.graph.all_ports(node))
+    fn all_subports(&self, node: NodeIndex) -> impl Iterator<Item = SubportIndex> {
+        self._all_subports(node)
     }
 }
 
@@ -459,7 +399,7 @@ impl MultiPortGraph {
         let link = self.graph.links(copy_node, dir).next();
         let link = link.map(|(_, tgt)| self.get_subport_from_index(tgt).unwrap());
 
-        let mut subports = self.graph.ports(copy_node, dir.reverse());
+        let mut subports = self.graph._ports(copy_node, dir.reverse());
         self.multiport.set(copy_port, false);
         self.multiport.set(main_node_port, false);
         self.copy_node.set(copy_node, false);
@@ -583,8 +523,8 @@ impl MultiPortGraph {
     /// Returns the PortIndex from the main node that connects to this copy node.
     fn copy_node_main_port(&self, copy_node: NodeIndex) -> Option<PortIndex> {
         debug_assert!(self.copy_node.get(copy_node));
-        let mut incoming = self.graph.inputs(copy_node);
-        let mut outgoing = self.graph.outputs(copy_node);
+        let mut incoming = self.graph._inputs(copy_node);
+        let mut outgoing = self.graph._outputs(copy_node);
 
         let internal_copy_port = match (incoming.len(), outgoing.len()) {
             (1, 1) => {

--- a/src/multiportgraph.rs
+++ b/src/multiportgraph.rs
@@ -129,7 +129,7 @@ impl PortView for MultiPortGraph {
     }
 
     #[inline]
-    fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex> {
+    fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex> + Clone {
         self::iter::Nodes {
             multigraph: self,
             iter: self.graph._nodes_iter(),
@@ -138,7 +138,7 @@ impl PortView for MultiPortGraph {
     }
 
     #[inline]
-    fn ports_iter(&self) -> impl Iterator<Item = PortIndex> {
+    fn ports_iter(&self) -> impl Iterator<Item = PortIndex> + Clone {
         Ports::new(self, self.graph._ports_iter())
     }
 
@@ -159,13 +159,13 @@ impl PortView for MultiPortGraph {
             fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
             fn port_offset(&self, port: impl Into<PortIndex>) -> Option<PortOffset>;
             fn port_index(&self, node: NodeIndex, offset: PortOffset) -> Option<PortIndex>;
-            fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex>;
-            fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex>;
+            fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex> + Clone;
+            fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone;
             fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
-            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset>;
-            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset>;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset> + Clone;
+            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone;
             fn node_port_capacity(&self, node: NodeIndex) -> usize;
         }
     }
@@ -264,7 +264,7 @@ impl LinkView for MultiPortGraph {
         &self,
         from: NodeIndex,
         to: NodeIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
         self._get_connections(from, to)
     }
 
@@ -272,7 +272,7 @@ impl LinkView for MultiPortGraph {
     fn port_links(
         &self,
         port: PortIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
         self._port_links(port)
     }
 
@@ -281,7 +281,7 @@ impl LinkView for MultiPortGraph {
         &self,
         node: NodeIndex,
         direction: Direction,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
         self._links(node, direction)
     }
 
@@ -289,17 +289,21 @@ impl LinkView for MultiPortGraph {
     fn all_links(
         &self,
         node: NodeIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
         self._all_links(node)
     }
 
     #[inline]
-    fn neighbours(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = NodeIndex> {
+    fn neighbours(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = NodeIndex> + Clone {
         self._neighbours(node, direction)
     }
 
     #[inline]
-    fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> {
+    fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + Clone {
         self._all_neighbours(node)
     }
 
@@ -347,12 +351,12 @@ impl MultiView for MultiPortGraph {
         &self,
         node: NodeIndex,
         direction: Direction,
-    ) -> impl Iterator<Item = SubportIndex> {
+    ) -> impl Iterator<Item = SubportIndex> + Clone {
         self._subports(node, direction)
     }
 
     #[inline]
-    fn all_subports(&self, node: NodeIndex) -> impl Iterator<Item = SubportIndex> {
+    fn all_subports(&self, node: NodeIndex) -> impl Iterator<Item = SubportIndex> + Clone {
         self._all_subports(node)
     }
 }

--- a/src/multiportgraph/iter.rs
+++ b/src/multiportgraph/iter.rs
@@ -15,26 +15,26 @@ impl MultiPortGraph {
     #[inline]
     /// Returns an iterator over every pair of matching ports connecting `from`
     /// with `to`.
-    pub fn _get_connections(&self, from: NodeIndex, to: NodeIndex) -> NodeConnections {
+    pub(crate) fn _get_connections(&self, from: NodeIndex, to: NodeIndex) -> NodeConnections {
         NodeConnections::new(self, to, self._output_links(from))
     }
 
     /// Returns the port that the given `port` is linked to.
     #[inline]
-    pub fn _port_links(&self, port: PortIndex) -> PortLinks {
+    pub(crate) fn _port_links(&self, port: PortIndex) -> PortLinks {
         PortLinks::new(self, port)
     }
 
     /// Iterates over the connected links of the `node` in the given
     /// `direction`.
     #[inline]
-    pub fn _links(&self, node: NodeIndex, direction: Direction) -> NodeLinks {
+    pub(crate) fn _links(&self, node: NodeIndex, direction: Direction) -> NodeLinks {
         NodeLinks::new(self, self.graph._ports(node, direction), 0..0)
     }
 
     /// Iterates over the connected input and output links of the `node` in sequence.
     #[inline]
-    pub fn _all_links(&self, node: NodeIndex) -> NodeLinks {
+    pub(crate) fn _all_links(&self, node: NodeIndex) -> NodeLinks {
         let output_ports = self.graph.node_outgoing_ports(node);
         NodeLinks::new(self, self.graph._all_ports(node), output_ports)
     }
@@ -43,32 +43,32 @@ impl MultiPortGraph {
     /// [`LinkView::links`].
     #[must_use]
     #[inline]
-    pub fn _output_links(&self, node: NodeIndex) -> NodeLinks {
+    pub(crate) fn _output_links(&self, node: NodeIndex) -> NodeLinks {
         self._links(node, Direction::Outgoing)
     }
 
     /// Iterates over neighbour nodes in the given `direction`.
     /// May contain duplicates if the graph has multiple links between nodes.
     #[inline]
-    pub fn _neighbours(&self, node: NodeIndex, direction: Direction) -> Neighbours {
+    pub(crate) fn _neighbours(&self, node: NodeIndex, direction: Direction) -> Neighbours {
         Neighbours::new(self, self._subports(node, direction), node, false)
     }
 
     /// Iterates over the input and output neighbours of the `node` in sequence.
     #[inline]
-    pub fn _all_neighbours(&self, node: NodeIndex) -> Neighbours {
+    pub(crate) fn _all_neighbours(&self, node: NodeIndex) -> Neighbours {
         Neighbours::new(self, self._all_subports(node), node, true)
     }
 
     /// Iterates over all the subports of the `node` in the given `direction`.
     #[inline]
-    pub fn _subports(&self, node: NodeIndex, direction: Direction) -> NodeSubports {
+    pub(crate) fn _subports(&self, node: NodeIndex, direction: Direction) -> NodeSubports {
         NodeSubports::new(self, self.graph._ports(node, direction))
     }
 
     /// Iterates over the input and output subports of the `node` in sequence.
     #[inline]
-    pub fn _all_subports(&self, node: NodeIndex) -> NodeSubports {
+    pub(crate) fn _all_subports(&self, node: NodeIndex) -> NodeSubports {
         NodeSubports::new(self, self.graph._all_ports(node))
     }
 }

--- a/src/portgraph.rs
+++ b/src/portgraph.rs
@@ -12,6 +12,7 @@
 
 mod iter;
 
+use delegate::delegate;
 use std::mem::{replace, take};
 use std::num::{NonZeroU16, NonZeroU32};
 use std::ops::Range;
@@ -352,18 +353,6 @@ impl PortView for PortGraph {
         node_meta.ports(direction).nth(offset).map(PortIndex::new)
     }
 
-    fn ports(
-        &self,
-        node: NodeIndex,
-        direction: Direction,
-    ) -> impl Iterator<Item = PortIndex> + Clone {
-        self._ports(node, direction)
-    }
-
-    fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone {
-        self._all_ports(node)
-    }
-
     #[inline]
     fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex> {
         self.port_index(node, PortOffset::new_incoming(offset))
@@ -383,19 +372,6 @@ impl PortView for PortGraph {
         } else {
             node_meta.outgoing() as usize
         }
-    }
-
-    fn port_offsets(
-        &self,
-        node: NodeIndex,
-        direction: Direction,
-    ) -> impl Iterator<Item = PortOffset> + Clone {
-        self._port_offsets(node, direction)
-    }
-
-    #[inline]
-    fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone {
-        self._all_port_offsets(node)
     }
 
     #[inline]
@@ -424,16 +400,6 @@ impl PortView for PortGraph {
     }
 
     #[inline]
-    fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex> + Clone {
-        self._nodes_iter()
-    }
-
-    #[inline]
-    fn ports_iter(&self) -> impl Iterator<Item = PortIndex> + Clone {
-        self._ports_iter()
-    }
-
-    #[inline]
     fn node_capacity(&self) -> usize {
         self.node_meta.capacity()
     }
@@ -447,6 +413,22 @@ impl PortView for PortGraph {
     fn node_port_capacity(&self, node: NodeIndex) -> usize {
         self.node_meta_valid(node)
             .map_or(0, |node_meta| node_meta.capacity())
+    }
+    delegate! {
+        to self {
+            #[call(_ports)]
+            fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex> + Clone;
+            #[call(_all_ports)]
+            fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone;
+            #[call(_port_offsets)]
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset> + Clone;
+            #[call(_all_port_offsets)]
+            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone;
+            #[call(_nodes_iter)]
+            fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex> + Clone;
+            #[call(_ports_iter)]
+            fn ports_iter(&self) -> impl Iterator<Item = PortIndex> + Clone;
+        }
     }
 }
 
@@ -728,15 +710,6 @@ impl PortMut for PortGraph {
 impl LinkView for PortGraph {
     type LinkEndpoint = PortIndex;
 
-    #[inline]
-    fn get_connections(
-        &self,
-        from: NodeIndex,
-        to: NodeIndex,
-    ) -> impl Iterator<Item = (PortIndex, PortIndex)> + Clone {
-        self._get_connections(from, to)
-    }
-
     fn port_links(&self, port: PortIndex) -> impl Iterator<Item = (PortIndex, PortIndex)> + Clone {
         self.port_meta_valid(port).unwrap();
         match self.port_link[port.index()] {
@@ -749,38 +722,24 @@ impl LinkView for PortGraph {
         }
     }
 
-    fn links(
-        &self,
-        node: NodeIndex,
-        direction: Direction,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
-        self._links(node, direction)
-    }
-
-    fn all_links(
-        &self,
-        node: NodeIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
-        self._all_links(node)
-    }
-
-    #[inline]
-    fn neighbours(
-        &self,
-        node: NodeIndex,
-        direction: Direction,
-    ) -> impl Iterator<Item = NodeIndex> + Clone {
-        self._neighbours(node, direction)
-    }
-
-    #[inline]
-    fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + Clone {
-        self._all_neighbours(node)
-    }
-
     #[inline]
     fn link_count(&self) -> usize {
         self.link_count
+    }
+
+    delegate! {
+        to self {
+            #[call(_get_connections)]
+            fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
+            #[call(_links)]
+            fn links(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
+            #[call(_all_links)]
+            fn all_links(&self, node: NodeIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
+            #[call(_neighbours)]
+            fn neighbours(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = NodeIndex> + Clone;
+            #[call(_all_neighbours)]
+            fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + Clone;
+        }
     }
 }
 

--- a/src/portgraph.rs
+++ b/src/portgraph.rs
@@ -352,11 +352,15 @@ impl PortView for PortGraph {
         node_meta.ports(direction).nth(offset).map(PortIndex::new)
     }
 
-    fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex> {
+    fn ports(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = PortIndex> + Clone {
         self._ports(node, direction)
     }
 
-    fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> {
+    fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone {
         self._all_ports(node)
     }
 
@@ -385,12 +389,12 @@ impl PortView for PortGraph {
         &self,
         node: NodeIndex,
         direction: Direction,
-    ) -> impl Iterator<Item = PortOffset> {
+    ) -> impl Iterator<Item = PortOffset> + Clone {
         self._port_offsets(node, direction)
     }
 
     #[inline]
-    fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> {
+    fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone {
         self._all_port_offsets(node)
     }
 
@@ -420,12 +424,12 @@ impl PortView for PortGraph {
     }
 
     #[inline]
-    fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex> {
+    fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex> + Clone {
         self._nodes_iter()
     }
 
     #[inline]
-    fn ports_iter(&self) -> impl Iterator<Item = PortIndex> {
+    fn ports_iter(&self) -> impl Iterator<Item = PortIndex> + Clone {
         self._ports_iter()
     }
 
@@ -729,11 +733,11 @@ impl LinkView for PortGraph {
         &self,
         from: NodeIndex,
         to: NodeIndex,
-    ) -> impl Iterator<Item = (PortIndex, PortIndex)> {
+    ) -> impl Iterator<Item = (PortIndex, PortIndex)> + Clone {
         self._get_connections(from, to)
     }
 
-    fn port_links(&self, port: PortIndex) -> impl Iterator<Item = (PortIndex, PortIndex)> {
+    fn port_links(&self, port: PortIndex) -> impl Iterator<Item = (PortIndex, PortIndex)> + Clone {
         self.port_meta_valid(port).unwrap();
         match self.port_link[port.index()] {
             Some(link) => std::iter::once((port, link)),
@@ -749,24 +753,28 @@ impl LinkView for PortGraph {
         &self,
         node: NodeIndex,
         direction: Direction,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
         self._links(node, direction)
     }
 
     fn all_links(
         &self,
         node: NodeIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
         self._all_links(node)
     }
 
     #[inline]
-    fn neighbours(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = NodeIndex> {
+    fn neighbours(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = NodeIndex> + Clone {
         self._neighbours(node, direction)
     }
 
     #[inline]
-    fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> {
+    fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + Clone {
         self._all_neighbours(node)
     }
 

--- a/src/portgraph/iter.rs
+++ b/src/portgraph/iter.rs
@@ -16,7 +16,7 @@ use crate::{NodeIndex, PortIndex, PortOffset};
 /// Used internally by other iterator implementations to avoid the generic RPITIT return types.
 impl PortGraph {
     /// Iterates over all the ports of the `node` in the given `direction`.
-    pub fn _ports(&self, node: NodeIndex, direction: Direction) -> NodePorts {
+    pub(crate) fn _ports(&self, node: NodeIndex, direction: Direction) -> NodePorts {
         match self.node_meta_valid(node) {
             Some(node_meta) => NodePorts {
                 indices: node_meta.ports(direction),
@@ -30,7 +30,7 @@ impl PortGraph {
     /// Shorthand for [`PortView::ports`].
     #[must_use]
     #[inline]
-    pub fn _inputs(&self, node: NodeIndex) -> NodePorts {
+    pub(crate) fn _inputs(&self, node: NodeIndex) -> NodePorts {
         self._ports(node, Direction::Incoming)
     }
 
@@ -39,12 +39,12 @@ impl PortGraph {
     /// Shorthand for [`PortView::ports`].
     #[must_use]
     #[inline]
-    pub fn _outputs(&self, node: NodeIndex) -> NodePorts {
+    pub(crate) fn _outputs(&self, node: NodeIndex) -> NodePorts {
         self._ports(node, Direction::Outgoing)
     }
 
     /// Iterates over the input and output ports of the `node` in sequence.
-    pub fn _all_ports(&self, node: NodeIndex) -> NodePorts {
+    pub(crate) fn _all_ports(&self, node: NodeIndex) -> NodePorts {
         match self.node_meta_valid(node) {
             Some(node_meta) => NodePorts {
                 indices: node_meta.all_ports(),
@@ -54,7 +54,7 @@ impl PortGraph {
     }
 
     /// Iterates over all the port offsets of the `node` in the given `direction`.
-    pub fn _port_offsets(&self, node: NodeIndex, direction: Direction) -> NodePortOffsets {
+    pub(crate) fn _port_offsets(&self, node: NodeIndex, direction: Direction) -> NodePortOffsets {
         match direction {
             Direction::Incoming => NodePortOffsets {
                 incoming: 0..self.num_inputs(node) as u16,
@@ -69,7 +69,7 @@ impl PortGraph {
 
     /// Iterates over the input and output port offsets of the `node` in sequence.
     #[inline]
-    pub fn _all_port_offsets(&self, node: NodeIndex) -> NodePortOffsets {
+    pub(crate) fn _all_port_offsets(&self, node: NodeIndex) -> NodePortOffsets {
         NodePortOffsets {
             incoming: 0..self.num_inputs(node) as u16,
             outgoing: 0..self.num_outputs(node) as u32,
@@ -78,7 +78,7 @@ impl PortGraph {
 
     /// Iterates over the nodes in the port graph.
     #[inline]
-    pub fn _nodes_iter(&self) -> Nodes {
+    pub(crate) fn _nodes_iter(&self) -> Nodes {
         Nodes {
             iter: self.node_meta.iter().enumerate(),
             len: self.node_count,
@@ -87,7 +87,7 @@ impl PortGraph {
 
     /// Iterates over the ports in the port graph.
     #[inline]
-    pub fn _ports_iter(&self) -> Ports {
+    pub(crate) fn _ports_iter(&self) -> Ports {
         Ports {
             iter: self.port_meta.iter().enumerate(),
             len: self.port_count,
@@ -97,13 +97,13 @@ impl PortGraph {
     /// Returns an iterator over every pair of matching ports connecting `from`
     /// with `to`.
     #[inline]
-    pub fn _get_connections(&self, from: NodeIndex, to: NodeIndex) -> NodeConnections {
+    pub(crate) fn _get_connections(&self, from: NodeIndex, to: NodeIndex) -> NodeConnections {
         NodeConnections::new(self, to, self._links(from, Direction::Outgoing))
     }
 
     /// Iterates over the connected links of the `node` in the given
     /// `direction`.
-    pub fn _links(&self, node: NodeIndex, direction: Direction) -> NodeLinks {
+    pub(crate) fn _links(&self, node: NodeIndex, direction: Direction) -> NodeLinks {
         let Some(node_meta) = self.node_meta_valid(node) else {
             return NodeLinks::new(self._ports(node, direction), &[], 0..0);
         };
@@ -112,7 +112,7 @@ impl PortGraph {
     }
 
     /// Iterates over the connected input and output links of the `node` in sequence.
-    pub fn _all_links(&self, node: NodeIndex) -> NodeLinks {
+    pub(crate) fn _all_links(&self, node: NodeIndex) -> NodeLinks {
         let Some(node_meta) = self.node_meta_valid(node) else {
             return NodeLinks::new(self._all_ports(node), &[], 0..0);
         };
@@ -129,13 +129,13 @@ impl PortGraph {
     /// Iterates over neighbour nodes in the given `direction`.
     /// May contain duplicates if the graph has multiple links between nodes.
     #[inline]
-    pub fn _neighbours(&self, node: NodeIndex, direction: Direction) -> Neighbours {
+    pub(crate) fn _neighbours(&self, node: NodeIndex, direction: Direction) -> Neighbours {
         Neighbours::from_node_links(self, self._links(node, direction))
     }
 
     /// Iterates over the input and output neighbours of the `node` in sequence.
     #[inline]
-    pub fn _all_neighbours(&self, node: NodeIndex) -> Neighbours {
+    pub(crate) fn _all_neighbours(&self, node: NodeIndex) -> Neighbours {
         Neighbours::from_node_links(self, self._all_links(node))
     }
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -36,18 +36,22 @@ pub trait PortView {
 
     /// Iterates over all the ports of the `node` in the given `direction`.
     #[must_use]
-    fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex>;
+    fn ports(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = PortIndex> + Clone;
 
     /// Iterates over the input and output ports of the `node` in sequence.
     #[must_use]
-    fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex>;
+    fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone;
 
     /// Iterates over all the input ports of the `node`.
     ///
     /// Shorthand for [`PortView::ports`].
     #[must_use]
     #[inline]
-    fn inputs(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> {
+    fn inputs(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone {
         self.ports(node, Direction::Incoming)
     }
 
@@ -56,7 +60,7 @@ pub trait PortView {
     /// Shorthand for [`PortView::ports`].
     #[must_use]
     #[inline]
-    fn outputs(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> {
+    fn outputs(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone {
         self.ports(node, Direction::Outgoing)
     }
 
@@ -111,18 +115,18 @@ pub trait PortView {
         &self,
         node: NodeIndex,
         direction: Direction,
-    ) -> impl Iterator<Item = PortOffset>;
+    ) -> impl Iterator<Item = PortOffset> + Clone;
 
     /// Iterates over the input and output port offsets of the `node` in sequence.
     #[must_use]
-    fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset>;
+    fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone;
 
     /// Iterates over all the input port offsets of the `node`.
     ///
     /// Shorthand for [`PortView::port_offsets`].
     #[must_use]
     #[inline]
-    fn input_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> {
+    fn input_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone {
         self.port_offsets(node, Direction::Incoming)
     }
 
@@ -131,7 +135,7 @@ pub trait PortView {
     /// Shorthand for [`PortView::port_offsets`].
     #[must_use]
     #[inline]
-    fn output_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> {
+    fn output_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone {
         self.port_offsets(node, Direction::Outgoing)
     }
 
@@ -157,11 +161,11 @@ pub trait PortView {
 
     /// Iterates over the nodes in the port graph.
     #[must_use]
-    fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex>;
+    fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex> + Clone;
 
     /// Iterates over the ports in the port graph.
     #[must_use]
-    fn ports_iter(&self) -> impl Iterator<Item = PortIndex>;
+    fn ports_iter(&self) -> impl Iterator<Item = PortIndex> + Clone;
 
     /// Returns the capacity of the underlying buffer for nodes.
     #[must_use]
@@ -298,7 +302,7 @@ pub trait LinkView: PortView {
         &self,
         from: NodeIndex,
         to: NodeIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
 
     /// Checks whether there is a directed link between the two nodes and
     /// returns the first matching pair of ports.
@@ -348,7 +352,7 @@ pub trait LinkView: PortView {
     fn port_links(
         &self,
         port: PortIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
 
     /// Return the link to the provided port, if not connected return None.
     /// If this port has multiple connected subports, an arbitrary one is returned.
@@ -384,14 +388,14 @@ pub trait LinkView: PortView {
         &self,
         node: NodeIndex,
         direction: Direction,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
 
     /// Iterates over the connected input and output links of the `node` in sequence.
     #[must_use]
     fn all_links(
         &self,
         node: NodeIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
 
     /// Iterates over the connected input links of the `node`. Shorthand for
     /// [`LinkView::links`].
@@ -400,7 +404,7 @@ pub trait LinkView: PortView {
     fn input_links(
         &self,
         node: NodeIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
         self.links(node, Direction::Incoming)
     }
 
@@ -411,7 +415,7 @@ pub trait LinkView: PortView {
     fn output_links(
         &self,
         node: NodeIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
         self.links(node, Direction::Outgoing)
     }
 
@@ -435,23 +439,27 @@ pub trait LinkView: PortView {
     /// assert!(graph.neighbours(b, Direction::Incoming).eq([a,b]));
     /// ```
     #[must_use]
-    fn neighbours(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = NodeIndex>;
+    fn neighbours(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = NodeIndex> + Clone;
 
     /// Iterates over the input and output neighbours of the `node` in sequence.
     #[must_use]
-    fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex>;
+    fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + Clone;
 
     /// Iterates over the input neighbours of the `node`. Shorthand for [`LinkView::neighbours`].
     #[must_use]
     #[inline]
-    fn input_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> {
+    fn input_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + Clone {
         self.neighbours(node, Direction::Incoming)
     }
 
     /// Iterates over the output neighbours of the `node`. Shorthand for [`LinkView::neighbours`].
     #[must_use]
     #[inline]
-    fn output_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> {
+    fn output_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + Clone {
         self.neighbours(node, Direction::Outgoing)
     }
 
@@ -582,18 +590,18 @@ pub trait MultiView: LinkView {
         &self,
         node: NodeIndex,
         direction: Direction,
-    ) -> impl Iterator<Item = Self::LinkEndpoint>;
+    ) -> impl Iterator<Item = Self::LinkEndpoint> + Clone;
 
     /// Iterates over the input and output subports of the `node` in sequence.
     #[must_use]
-    fn all_subports(&self, node: NodeIndex) -> impl Iterator<Item = Self::LinkEndpoint>;
+    fn all_subports(&self, node: NodeIndex) -> impl Iterator<Item = Self::LinkEndpoint> + Clone;
 
     /// Iterates over all the input subports of the `node`.
     ///
     /// Shorthand for [`MultiView::subports`].
     #[must_use]
     #[inline]
-    fn subport_inputs(&self, node: NodeIndex) -> impl Iterator<Item = Self::LinkEndpoint> {
+    fn subport_inputs(&self, node: NodeIndex) -> impl Iterator<Item = Self::LinkEndpoint> + Clone {
         self.subports(node, Direction::Incoming)
     }
 
@@ -602,7 +610,7 @@ pub trait MultiView: LinkView {
     /// Shorthand for [`MultiView::subports`].
     #[must_use]
     #[inline]
-    fn subport_outputs(&self, node: NodeIndex) -> impl Iterator<Item = Self::LinkEndpoint> {
+    fn subport_outputs(&self, node: NodeIndex) -> impl Iterator<Item = Self::LinkEndpoint> + Clone {
         self.subports(node, Direction::Outgoing)
     }
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -18,26 +18,6 @@ pub use subgraph::Subgraph;
 
 /// Core capabilities for querying a graph containing nodes and ports.
 pub trait PortView {
-    /// Iterator over the nodes of the graph.
-    type Nodes<'a>: Iterator<Item = NodeIndex>
-    where
-        Self: 'a;
-
-    /// Iterator over the ports of the graph.
-    type Ports<'a>: Iterator<Item = PortIndex>
-    where
-        Self: 'a;
-
-    /// Iterator over the ports of a node.
-    type NodePorts<'a>: Iterator<Item = PortIndex>
-    where
-        Self: 'a;
-
-    /// Iterator over the port offsets in a node.
-    type NodePortOffsets<'a>: Iterator<Item = PortOffset>
-    where
-        Self: 'a;
-
     /// Returns the direction of the `port`.
     #[must_use]
     fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction>;
@@ -56,18 +36,18 @@ pub trait PortView {
 
     /// Iterates over all the ports of the `node` in the given `direction`.
     #[must_use]
-    fn ports(&self, node: NodeIndex, direction: Direction) -> Self::NodePorts<'_>;
+    fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex>;
 
     /// Iterates over the input and output ports of the `node` in sequence.
     #[must_use]
-    fn all_ports(&self, node: NodeIndex) -> Self::NodePorts<'_>;
+    fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex>;
 
     /// Iterates over all the input ports of the `node`.
     ///
     /// Shorthand for [`PortView::ports`].
     #[must_use]
     #[inline]
-    fn inputs(&self, node: NodeIndex) -> Self::NodePorts<'_> {
+    fn inputs(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> {
         self.ports(node, Direction::Incoming)
     }
 
@@ -76,7 +56,7 @@ pub trait PortView {
     /// Shorthand for [`PortView::ports`].
     #[must_use]
     #[inline]
-    fn outputs(&self, node: NodeIndex) -> Self::NodePorts<'_> {
+    fn outputs(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> {
         self.ports(node, Direction::Outgoing)
     }
 
@@ -127,18 +107,22 @@ pub trait PortView {
     /// assert!(graph.port_offsets(node, Direction::Outgoing).eq([PortOffset::new_outgoing(0), PortOffset::new_outgoing(1)]));
     /// ```
     #[must_use]
-    fn port_offsets(&self, node: NodeIndex, direction: Direction) -> Self::NodePortOffsets<'_>;
+    fn port_offsets(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = PortOffset>;
 
     /// Iterates over the input and output port offsets of the `node` in sequence.
     #[must_use]
-    fn all_port_offsets(&self, node: NodeIndex) -> Self::NodePortOffsets<'_>;
+    fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset>;
 
     /// Iterates over all the input port offsets of the `node`.
     ///
     /// Shorthand for [`PortView::port_offsets`].
     #[must_use]
     #[inline]
-    fn input_offsets(&self, node: NodeIndex) -> Self::NodePortOffsets<'_> {
+    fn input_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> {
         self.port_offsets(node, Direction::Incoming)
     }
 
@@ -147,7 +131,7 @@ pub trait PortView {
     /// Shorthand for [`PortView::port_offsets`].
     #[must_use]
     #[inline]
-    fn output_offsets(&self, node: NodeIndex) -> Self::NodePortOffsets<'_> {
+    fn output_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> {
         self.port_offsets(node, Direction::Outgoing)
     }
 
@@ -173,11 +157,11 @@ pub trait PortView {
 
     /// Iterates over the nodes in the port graph.
     #[must_use]
-    fn nodes_iter(&self) -> Self::Nodes<'_>;
+    fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex>;
 
     /// Iterates over the ports in the port graph.
     #[must_use]
-    fn ports_iter(&self) -> Self::Ports<'_>;
+    fn ports_iter(&self) -> impl Iterator<Item = PortIndex>;
 
     /// Returns the capacity of the underlying buffer for nodes.
     #[must_use]
@@ -225,8 +209,12 @@ pub trait PortMut: PortView {
     /// let mut g = PortGraph::new();
     /// let node0 = g.add_node(1, 1);
     /// let node1 = g.add_node(1, 1);
-    /// g.link_ports(g.outputs(node0).nth(0).unwrap(), g.inputs(node1).nth(0).unwrap());
-    /// g.link_ports(g.outputs(node1).nth(0).unwrap(), g.inputs(node0).nth(0).unwrap());
+    /// let out0 = g.outputs(node0).nth(0).unwrap();
+    /// let out1 = g.outputs(node1).nth(0).unwrap();
+    /// let in0 = g.inputs(node0).nth(0).unwrap();
+    /// let in1 = g.inputs(node1).nth(0).unwrap();
+    /// g.link_ports(out0, in1);
+    /// g.link_ports(out1, in0);
     /// g.remove_node(node0);
     /// assert!(!g.contains_node(node0));
     /// assert!(g.port_link(g.outputs(node1).nth(0).unwrap()).is_none());
@@ -287,28 +275,6 @@ pub trait LinkView: PortView {
     /// The identifier for the endpoints of a link.
     type LinkEndpoint: Into<PortIndex> + Copy;
 
-    /// Iterator over the neighbours of a node.
-    type Neighbours<'a>: Iterator<Item = NodeIndex>
-    where
-        Self: 'a;
-
-    /// Iterator over the connections between two nodes.
-    type NodeConnections<'a>: Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>
-    where
-        Self: 'a;
-
-    /// Iterator over the links of a node. Returns pairs of source subport in
-    /// the given node and target subport in the linked node.
-    type NodeLinks<'a>: Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>
-    where
-        Self: 'a;
-
-    /// Iterator over the links of a port. Returns pairs of source subport in
-    /// the given ports and target subport in the linked port.
-    type PortLinks<'a>: Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>
-    where
-        Self: 'a;
-
     /// Returns an iterator over every pair of matching ports connecting `from`
     /// with `to`.
     ///
@@ -328,7 +294,11 @@ pub trait LinkView: PortView {
     /// assert_eq!(connections.next(), None);
     /// ```
     #[must_use]
-    fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> Self::NodeConnections<'_>;
+    fn get_connections(
+        &self,
+        from: NodeIndex,
+        to: NodeIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
 
     /// Checks whether there is a directed link between the two nodes and
     /// returns the first matching pair of ports.
@@ -375,7 +345,10 @@ pub trait LinkView: PortView {
 
     /// Returns the port that the given `port` is linked to.
     #[must_use]
-    fn port_links(&self, port: PortIndex) -> Self::PortLinks<'_>;
+    fn port_links(
+        &self,
+        port: PortIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
 
     /// Return the link to the provided port, if not connected return None.
     /// If this port has multiple connected subports, an arbitrary one is returned.
@@ -407,17 +380,27 @@ pub trait LinkView: PortView {
     /// assert!(graph.links(node_b, Direction::Incoming).eq([(port_b, port_a)]));
     /// ```
     #[must_use]
-    fn links(&self, node: NodeIndex, direction: Direction) -> Self::NodeLinks<'_>;
+    fn links(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
 
     /// Iterates over the connected input and output links of the `node` in sequence.
     #[must_use]
-    fn all_links(&self, node: NodeIndex) -> Self::NodeLinks<'_>;
+    fn all_links(
+        &self,
+        node: NodeIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
 
     /// Iterates over the connected input links of the `node`. Shorthand for
     /// [`LinkView::links`].
     #[must_use]
     #[inline]
-    fn input_links(&self, node: NodeIndex) -> Self::NodeLinks<'_> {
+    fn input_links(
+        &self,
+        node: NodeIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
         self.links(node, Direction::Incoming)
     }
 
@@ -425,7 +408,10 @@ pub trait LinkView: PortView {
     /// [`LinkView::links`].
     #[must_use]
     #[inline]
-    fn output_links(&self, node: NodeIndex) -> Self::NodeLinks<'_> {
+    fn output_links(
+        &self,
+        node: NodeIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
         self.links(node, Direction::Outgoing)
     }
 
@@ -449,23 +435,23 @@ pub trait LinkView: PortView {
     /// assert!(graph.neighbours(b, Direction::Incoming).eq([a,b]));
     /// ```
     #[must_use]
-    fn neighbours(&self, node: NodeIndex, direction: Direction) -> Self::Neighbours<'_>;
+    fn neighbours(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = NodeIndex>;
 
     /// Iterates over the input and output neighbours of the `node` in sequence.
     #[must_use]
-    fn all_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_>;
+    fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex>;
 
     /// Iterates over the input neighbours of the `node`. Shorthand for [`LinkView::neighbours`].
     #[must_use]
     #[inline]
-    fn input_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_> {
+    fn input_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> {
         self.neighbours(node, Direction::Incoming)
     }
 
     /// Iterates over the output neighbours of the `node`. Shorthand for [`LinkView::neighbours`].
     #[must_use]
     #[inline]
-    fn output_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_> {
+    fn output_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> {
         self.neighbours(node, Direction::Outgoing)
     }
 
@@ -585,11 +571,6 @@ pub trait LinkMut: LinkView + PortMut {
 
 /// Abstraction over a portgraph that may have multiple connections per node.
 pub trait MultiView: LinkView {
-    /// Iterator over all the subports of a node.
-    type NodeSubports<'a>: Iterator<Item = Self::LinkEndpoint>
-    where
-        Self: 'a;
-
     /// Return the subport linked to the given `port`. If the port is not
     /// connected, return None.
     #[must_use]
@@ -597,18 +578,22 @@ pub trait MultiView: LinkView {
 
     /// Iterates over all the subports of the `node` in the given `direction`.
     #[must_use]
-    fn subports(&self, node: NodeIndex, direction: Direction) -> Self::NodeSubports<'_>;
+    fn subports(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = Self::LinkEndpoint>;
 
     /// Iterates over the input and output subports of the `node` in sequence.
     #[must_use]
-    fn all_subports(&self, node: NodeIndex) -> Self::NodeSubports<'_>;
+    fn all_subports(&self, node: NodeIndex) -> impl Iterator<Item = Self::LinkEndpoint>;
 
     /// Iterates over all the input subports of the `node`.
     ///
     /// Shorthand for [`MultiView::subports`].
     #[must_use]
     #[inline]
-    fn subport_inputs(&self, node: NodeIndex) -> Self::NodeSubports<'_> {
+    fn subport_inputs(&self, node: NodeIndex) -> impl Iterator<Item = Self::LinkEndpoint> {
         self.subports(node, Direction::Incoming)
     }
 
@@ -617,7 +602,7 @@ pub trait MultiView: LinkView {
     /// Shorthand for [`MultiView::subports`].
     #[must_use]
     #[inline]
-    fn subport_outputs(&self, node: NodeIndex) -> Self::NodeSubports<'_> {
+    fn subport_outputs(&self, node: NodeIndex) -> impl Iterator<Item = Self::LinkEndpoint> {
         self.subports(node, Direction::Outgoing)
     }
 }

--- a/src/view/filter.rs
+++ b/src/view/filter.rs
@@ -142,12 +142,12 @@ where
     }
 
     #[inline]
-    fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex> {
+    fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex> + Clone {
         self.graph.nodes_iter().filter(|n| self.node_filter(n))
     }
 
     #[inline]
-    fn ports_iter(&self) -> impl Iterator<Item = PortIndex> {
+    fn ports_iter(&self) -> impl Iterator<Item = PortIndex> + Clone {
         self.graph.ports_iter().filter(|p| self.port_filter(p))
     }
 
@@ -157,13 +157,13 @@ where
             fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
             fn port_offset(&self, port: impl Into<PortIndex>) -> Option<crate::PortOffset>;
             fn port_index(&self, node: NodeIndex, offset: crate::PortOffset) -> Option<PortIndex>;
-            fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex>;
-            fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex>;
+            fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex> + Clone;
+            fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone;
             fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
-            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset>;
-            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset>;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset> + Clone;
+            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone;
             fn node_capacity(&self) -> usize;
             fn port_capacity(&self) -> usize;
             fn node_port_capacity(&self, node: NodeIndex) -> usize;
@@ -181,7 +181,7 @@ where
         &self,
         from: NodeIndex,
         to: NodeIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
         self.graph
             .get_connections(from, to)
             .filter(|l| self.link_filter(l))
@@ -190,7 +190,7 @@ where
     fn port_links(
         &self,
         port: PortIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
         self.graph.port_links(port).filter(|l| self.link_filter(l))
     }
 
@@ -198,7 +198,7 @@ where
         &self,
         node: NodeIndex,
         direction: Direction,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
         self.graph
             .links(node, direction)
             .filter(|l| self.link_filter(l))
@@ -207,16 +207,20 @@ where
     fn all_links(
         &self,
         node: NodeIndex,
-    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> {
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
         self.graph.all_links(node).filter(|l| self.link_filter(l))
     }
 
-    fn neighbours(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = NodeIndex> {
+    fn neighbours(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = NodeIndex> + Clone {
         self.links(node, direction)
             .map(|(_, p)| self.graph.port_node(p).unwrap())
     }
 
-    fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> {
+    fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + Clone {
         self.all_links(node)
             .map(|(_, p)| self.graph.port_node(p).unwrap())
     }
@@ -236,13 +240,13 @@ where
         &self,
         node: NodeIndex,
         direction: Direction,
-    ) -> impl Iterator<Item = Self::LinkEndpoint> {
+    ) -> impl Iterator<Item = Self::LinkEndpoint> + Clone {
         self.graph
             .subports(node, direction)
             .filter(|p| self.port_filter(p))
     }
 
-    fn all_subports(&self, node: NodeIndex) -> impl Iterator<Item = Self::LinkEndpoint> {
+    fn all_subports(&self, node: NodeIndex) -> impl Iterator<Item = Self::LinkEndpoint> + Clone {
         self.graph
             .all_subports(node)
             .filter(|p| self.port_filter(p))

--- a/src/view/refs.rs
+++ b/src/view/refs.rs
@@ -10,42 +10,26 @@ use delegate::delegate;
 use super::{LinkView, PortView};
 
 impl<'g, G: PortView> PortView for &'g G {
-    type Nodes<'a> = G::Nodes<'a>
-    where
-        Self: 'a;
-
-    type Ports<'a> = G::Ports<'a>
-    where
-        Self: 'a;
-
-    type NodePorts<'a> = G::NodePorts<'a>
-    where
-        Self: 'a;
-
-    type NodePortOffsets<'a> = G::NodePortOffsets<'a>
-    where
-        Self: 'a;
-
     delegate! {
         to (*self) {
             fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction>;
             fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
             fn port_offset(&self, port: impl Into<PortIndex>) -> Option<PortOffset>;
             fn port_index(&self, node: NodeIndex, offset: PortOffset) -> Option<PortIndex>;
-            fn ports(&self, node: NodeIndex, direction: Direction) -> Self::NodePorts<'_>;
-            fn all_ports(&self, node: NodeIndex) -> Self::NodePorts<'_>;
+            fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex>;
+            fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex>;
             fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
-            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> Self::NodePortOffsets<'_>;
-            fn all_port_offsets(&self, node: NodeIndex) -> Self::NodePortOffsets<'_>;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset>;
+            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset>;
             fn contains_node(&self, node: NodeIndex) -> bool;
             fn contains_port(&self, port: PortIndex) -> bool;
             fn is_empty(&self) -> bool;
             fn node_count(&self) -> usize;
             fn port_count(&self) -> usize;
-            fn nodes_iter(&self) -> Self::Nodes<'_>;
-            fn ports_iter(&self) -> Self::Ports<'_>;
+            fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex>;
+            fn ports_iter(&self) -> impl Iterator<Item = PortIndex>;
             fn node_capacity(&self) -> usize;
             fn port_capacity(&self) -> usize;
             fn node_port_capacity(&self, node: NodeIndex) -> usize;
@@ -56,30 +40,14 @@ impl<'g, G: PortView> PortView for &'g G {
 impl<'g, G: LinkView> LinkView for &'g G {
     type LinkEndpoint = G::LinkEndpoint;
 
-    type Neighbours<'a> = G::Neighbours<'a>
-    where
-        Self: 'a;
-
-    type NodeConnections<'a> = G::NodeConnections<'a>
-    where
-        Self: 'a;
-
-    type NodeLinks<'a> = G::NodeLinks<'a>
-    where
-        Self: 'a;
-
-    type PortLinks<'a> = G::PortLinks<'a>
-    where
-        Self: 'a;
-
     delegate! {
         to (*self) {
-            fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> Self::NodeConnections<'_>;
-            fn port_links(&self, port: PortIndex) -> Self::PortLinks<'_>;
-            fn links(&self, node: NodeIndex, direction: Direction) -> Self::NodeLinks<'_>;
-            fn all_links(&self, node: NodeIndex) -> Self::NodeLinks<'_>;
-            fn neighbours(&self, node: NodeIndex, direction: Direction) -> Self::Neighbours<'_>;
-            fn all_neighbours(&self, node: NodeIndex) -> Self::Neighbours<'_>;
+            fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
+            fn port_links(&self, port: PortIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
+            fn links(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
+            fn all_links(&self, node: NodeIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
+            fn neighbours(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = NodeIndex>;
+            fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex>;
             fn link_count(&self) -> usize;
         }
     }

--- a/src/view/refs.rs
+++ b/src/view/refs.rs
@@ -7,7 +7,7 @@ use crate::{Direction, NodeIndex, PortIndex, PortOffset};
 
 use delegate::delegate;
 
-use super::{LinkView, PortView};
+use super::{LinkView, MultiView, PortView};
 
 impl<'g, G: PortView> PortView for &'g G {
     delegate! {
@@ -16,20 +16,20 @@ impl<'g, G: PortView> PortView for &'g G {
             fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
             fn port_offset(&self, port: impl Into<PortIndex>) -> Option<PortOffset>;
             fn port_index(&self, node: NodeIndex, offset: PortOffset) -> Option<PortIndex>;
-            fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex>;
-            fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex>;
+            fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex> + Clone;
+            fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone;
             fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
-            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset>;
-            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset>;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset> + Clone;
+            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone;
             fn contains_node(&self, node: NodeIndex) -> bool;
             fn contains_port(&self, port: PortIndex) -> bool;
             fn is_empty(&self) -> bool;
             fn node_count(&self) -> usize;
             fn port_count(&self) -> usize;
-            fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex>;
-            fn ports_iter(&self) -> impl Iterator<Item = PortIndex>;
+            fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex> + Clone;
+            fn ports_iter(&self) -> impl Iterator<Item = PortIndex> + Clone;
             fn node_capacity(&self) -> usize;
             fn port_capacity(&self) -> usize;
             fn node_port_capacity(&self, node: NodeIndex) -> usize;
@@ -42,15 +42,25 @@ impl<'g, G: LinkView> LinkView for &'g G {
 
     delegate! {
         to (*self) {
-            fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
-            fn port_links(&self, port: PortIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
-            fn links(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
-            fn all_links(&self, node: NodeIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)>;
-            fn neighbours(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = NodeIndex>;
-            fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex>;
+            fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
+            fn port_links(&self, port: PortIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
+            fn links(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
+            fn all_links(&self, node: NodeIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
+            fn neighbours(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = NodeIndex> + Clone;
+            fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + Clone;
             fn link_count(&self) -> usize;
         }
     }
 }
 
-// TODO: PortMut, LinkMut, MultiView, MultiMut
+impl<'g, G: MultiView> MultiView for &'g G {
+    delegate! {
+        to (*self) {
+            fn subports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = Self::LinkEndpoint> + Clone;
+            fn all_subports(&self, node: NodeIndex) -> impl Iterator<Item = Self::LinkEndpoint> + Clone;
+            fn subport_link(&self, subport: Self::LinkEndpoint) -> Option<Self::LinkEndpoint>;
+        }
+    }
+}
+
+// TODO: PortMut, LinkMut, MultiMut


### PR DESCRIPTION
Closes #119

This should simplify the implementation of #155, and any other new wrapper.

BREAKING CHANGE: Graph trait methods now return `impl Iterator`s instead of named associated types.