### PR TITLE
perf!: Fix Subgraph O(n) complexity

### DIFF
--- a/src/view/filter.rs
+++ b/src/view/filter.rs
@@ -52,10 +52,6 @@ where
     pub fn context(&self) -> &Ctx {
         &self.context
     }
-
-    pub(super) fn graph(&self) -> G {
-        self.graph.clone()
-    }
 }
 
 impl<G, F, Ctx> NodeFiltered<G, F, Ctx>

--- a/src/view/subgraph.rs
+++ b/src/view/subgraph.rs
@@ -111,13 +111,21 @@ where
     }
 
     /// Whether the subgraph is convex.
+    #[inline]
     pub fn is_convex(&self) -> bool {
+        if self.node_count() <= 1 {
+            return true;
+        }
         let checker = TopoConvexChecker::new(&self.graph);
         self.is_convex_with_checker(&checker)
     }
 
     /// Whether the subgraph is convex, using a pre-existing checker.
+    #[inline]
     pub fn is_convex_with_checker(&self, checker: &impl ConvexChecker) -> bool {
+        if self.node_count() <= 1 {
+            return true;
+        }
         checker.is_convex(
             self.nodes_iter(),
             self.inputs.iter().copied(),

--- a/src/view/subgraph.rs
+++ b/src/view/subgraph.rs
@@ -37,7 +37,7 @@ use super::{MultiView, PortView};
 /// An intuitive way of looking at this definition is to imagine that the
 /// boundary edges form a wall around the subgraph, and the subgraph is given
 /// by all nodes and edges that can be reached from within without crossing the
-/// wall. The directness of edges (incoming/outgoing) defines which side of
+/// wall. The [Direction] of edges (incoming/outgoing) defines which side of
 /// the wall is inside, and which is outside.
 ///
 /// If both incoming and outgoing boundary edges are empty, the subgraph is
@@ -46,7 +46,7 @@ use super::{MultiView, PortView};
 /// If an invalid subgraph is defined, then behaviour is undefined.
 ///
 /// If any graph method is called with a node or port that is not in the subgraph,
-/// the behaviour is undefined.
+/// the behaviour is unspecified.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Subgraph<G> {
     /// The base graph.


### PR DESCRIPTION
Replaced the `Subgraph = FilteredGraph` alias with a concrete definition that avoids traversing the whole graph to filter nodes all the time.
Now `Subgraph::iter_nodes` is `O(nodes in subgraph)` instead of `O(n)`.

Closes #155.

BREAKING CHANGE: `Subgraph` is no longer an alias for `FilteredGraph`