### PR TITLE
perf!: Manual impl of `Region`/`FlatRegion` for improved perf

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -2,8 +2,10 @@
 
 pub mod filter;
 pub mod refs;
-pub mod region;
-pub mod subgraph;
+
+mod flat_region;
+mod region;
+mod subgraph;
 
 #[cfg(feature = "petgraph")]
 pub mod petgraph;
@@ -13,7 +15,8 @@ use std::collections::HashMap;
 use crate::{portgraph::PortOperation, Direction, LinkError, NodeIndex, PortIndex, PortOffset};
 
 pub use filter::{FilteredGraph, LinkFilter, NodeFilter, NodeFiltered};
-pub use region::{FlatRegion, Region};
+pub use flat_region::FlatRegion;
+pub use region::Region;
 pub use subgraph::Subgraph;
 
 /// Core capabilities for querying a graph containing nodes and ports.

--- a/src/view/flat_region.rs
+++ b/src/view/flat_region.rs
@@ -1,27 +1,218 @@
 //! Views of a portgraph containing only the descendants of a node in a [`Hierarchy`].
 
-use super::filter::NodeFiltered;
-use crate::{Hierarchy, NodeIndex};
+use super::{LinkView, MultiView, PortView};
+use crate::{Direction, Hierarchy, NodeIndex, PortIndex, PortOffset};
 
-type FlatRegionContext<'g> = (&'g Hierarchy, NodeIndex);
-type FlatRegionCallback<'g> = fn(NodeIndex, &FlatRegionContext<'g>) -> bool;
+use delegate::delegate;
+use itertools::Either;
 
 /// View of a portgraph containing only a root node and its direct children in a [`Hierarchy`].
 ///
 /// For a view of all descendants, see [`crate::view::Region`].
-pub type FlatRegion<'g, G> = NodeFiltered<G, FlatRegionCallback<'g>, FlatRegionContext<'g>>;
+#[derive(Debug, Clone, PartialEq)]
+pub struct FlatRegion<'g, G> {
+    /// The base graph
+    graph: G,
+    /// The root node of the region
+    region_root: NodeIndex,
+    /// The graph's hierarchy
+    hierarchy: &'g Hierarchy,
+}
 
 impl<'a, G> FlatRegion<'a, G>
 where
     G: Clone,
 {
     /// Create a new region view including all the descendants of the root node.
-    pub fn new_flat_region(graph: G, hierarchy: &'a Hierarchy, root: NodeIndex) -> Self {
-        let region_filter: FlatRegionCallback<'a> = |node, context| {
-            let (hierarchy, root) = context;
-            node == *root || hierarchy.parent(node) == Some(*root)
+    pub fn new(graph: G, hierarchy: &'a Hierarchy, root: NodeIndex) -> Self {
+        Self {
+            graph,
+            region_root: root,
+            hierarchy,
+        }
+    }
+}
+
+impl<'g, G> FlatRegion<'g, G>
+where
+    G: LinkView + Clone,
+{
+    /// Utility function to filter out links that are not in the subgraph.
+    #[inline(always)]
+    fn contains_link(&self, (from, to): (G::LinkEndpoint, G::LinkEndpoint)) -> bool {
+        self.contains_endpoint(from) && self.contains_endpoint(to)
+    }
+
+    /// Utility function to filter out link endpoints that are not in the subgraph.
+    #[inline(always)]
+    fn contains_endpoint(&self, e: G::LinkEndpoint) -> bool {
+        self.contains_port(e.into())
+    }
+}
+
+impl<'g, G> PortView for FlatRegion<'g, G>
+where
+    G: PortView + Clone,
+{
+    #[inline(always)]
+    fn contains_node(&'_ self, node: NodeIndex) -> bool {
+        node == self.region_root || self.hierarchy.parent(node) == Some(self.region_root)
+    }
+
+    #[inline(always)]
+    fn contains_port(&self, port: PortIndex) -> bool {
+        let Some(node) = self.graph.port_node(port) else {
+            return false;
         };
-        Self::new_node_filtered(graph, region_filter, (hierarchy, root))
+        self.contains_node(node)
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    fn node_count(&self) -> usize {
+        self.hierarchy.child_count(self.region_root) + 1
+    }
+
+    #[inline]
+    fn port_count(&self) -> usize {
+        self.ports_iter().count()
+    }
+
+    #[inline]
+    fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex> + Clone {
+        std::iter::once(self.region_root).chain(self.hierarchy.children(self.region_root))
+    }
+
+    #[inline]
+    fn ports_iter(&self) -> impl Iterator<Item = PortIndex> + Clone {
+        self.nodes_iter().flat_map(|n| self.graph.all_ports(n))
+    }
+
+    #[inline]
+    fn node_capacity(&self) -> usize {
+        self.graph.node_capacity() - self.graph.node_count() + self.node_count()
+    }
+
+    #[inline]
+    fn port_capacity(&self) -> usize {
+        self.graph.port_capacity() - self.graph.port_count() + self.port_count()
+    }
+
+    delegate! {
+        to self.graph {
+            fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction>;
+            fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
+            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<crate::PortOffset>;
+            fn port_index(&self, node: NodeIndex, offset: crate::PortOffset) -> Option<PortIndex>;
+            fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex> + Clone;
+            fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone;
+            fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
+            fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
+            fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset> + Clone;
+            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone;
+            fn node_port_capacity(&self, node: NodeIndex) -> usize;
+        }
+    }
+}
+
+impl<'g, G> LinkView for FlatRegion<'g, G>
+where
+    G: LinkView + Clone,
+{
+    type LinkEndpoint = G::LinkEndpoint;
+
+    fn get_connections(
+        &self,
+        from: NodeIndex,
+        to: NodeIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
+        if self.contains_node(from) && self.contains_node(to) {
+            Either::Left(self.graph.get_connections(from, to))
+        } else {
+            Either::Right(std::iter::empty())
+        }
+    }
+
+    fn port_links(
+        &self,
+        port: PortIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
+        self.graph
+            .port_links(port)
+            .filter(|&lnk| self.contains_link(lnk))
+    }
+
+    fn links(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
+        self.graph
+            .links(node, direction)
+            .filter(|&lnk| self.contains_link(lnk))
+    }
+
+    fn all_links(
+        &self,
+        node: NodeIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
+        self.graph
+            .all_links(node)
+            .filter(|&lnk| self.contains_link(lnk))
+    }
+
+    fn neighbours(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = NodeIndex> + Clone {
+        self.graph
+            .neighbours(node, direction)
+            .filter(|&n| self.contains_node(n))
+    }
+
+    fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + Clone {
+        self.graph
+            .all_neighbours(node)
+            .filter(|&n| self.contains_node(n))
+    }
+
+    fn link_count(&self) -> usize {
+        self.nodes_iter()
+            .flat_map(|node| self.links(node, Direction::Outgoing))
+            .count()
+    }
+}
+
+impl<'g, G> MultiView for FlatRegion<'g, G>
+where
+    G: MultiView + Clone,
+{
+    fn subports(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = Self::LinkEndpoint> + Clone {
+        self.graph
+            .subports(node, direction)
+            .filter(|&p| self.contains_endpoint(p))
+    }
+
+    fn all_subports(&self, node: NodeIndex) -> impl Iterator<Item = Self::LinkEndpoint> + Clone {
+        self.graph
+            .all_subports(node)
+            .filter(|&p| self.contains_endpoint(p))
+    }
+
+    fn subport_link(&self, subport: Self::LinkEndpoint) -> Option<Self::LinkEndpoint> {
+        self.graph
+            .subport_link(subport)
+            .filter(|&p| self.contains_endpoint(p))
     }
 }
 
@@ -29,7 +220,7 @@ where
 mod test {
     use std::error::Error;
 
-    use crate::{Hierarchy, LinkMut, LinkView, PortGraph, PortMut, PortView};
+    use crate::{Hierarchy, LinkMut, PortGraph, PortMut};
 
     use super::*;
 
@@ -40,7 +231,7 @@ mod test {
 
         let hierarchy = Hierarchy::new();
 
-        let region = FlatRegion::new_flat_region(&graph, &hierarchy, root);
+        let region = FlatRegion::new(&graph, &hierarchy, root);
         assert_eq!(region.node_count(), 1);
         assert_eq!(region.port_count(), 0);
     }
@@ -60,7 +251,7 @@ mod test {
         hierarchy.push_child(b, root)?;
         hierarchy.push_child(c, b)?;
 
-        let region = FlatRegion::new_flat_region(&graph, &hierarchy, root);
+        let region = FlatRegion::new(&graph, &hierarchy, root);
 
         assert!(region.nodes_iter().eq([root, a, b]));
         assert_eq!(region.node_count(), 3);

--- a/src/view/flat_region.rs
+++ b/src/view/flat_region.rs
@@ -1,0 +1,75 @@
+//! Views of a portgraph containing only the descendants of a node in a [`Hierarchy`].
+
+use super::filter::NodeFiltered;
+use crate::{Hierarchy, NodeIndex};
+
+type FlatRegionContext<'g> = (&'g Hierarchy, NodeIndex);
+type FlatRegionCallback<'g> = fn(NodeIndex, &FlatRegionContext<'g>) -> bool;
+
+/// View of a portgraph containing only a root node and its direct children in a [`Hierarchy`].
+///
+/// For a view of all descendants, see [`crate::view::Region`].
+pub type FlatRegion<'g, G> = NodeFiltered<G, FlatRegionCallback<'g>, FlatRegionContext<'g>>;
+
+impl<'a, G> FlatRegion<'a, G>
+where
+    G: Clone,
+{
+    /// Create a new region view including all the descendants of the root node.
+    pub fn new_flat_region(graph: G, hierarchy: &'a Hierarchy, root: NodeIndex) -> Self {
+        let region_filter: FlatRegionCallback<'a> = |node, context| {
+            let (hierarchy, root) = context;
+            node == *root || hierarchy.parent(node) == Some(*root)
+        };
+        Self::new_node_filtered(graph, region_filter, (hierarchy, root))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::error::Error;
+
+    use crate::{Hierarchy, LinkMut, LinkView, PortGraph, PortMut, PortView};
+
+    use super::*;
+
+    #[test]
+    fn single_node_region() {
+        let mut graph = PortGraph::new();
+        let root = graph.add_node(0, 0);
+
+        let hierarchy = Hierarchy::new();
+
+        let region = FlatRegion::new_flat_region(&graph, &hierarchy, root);
+        assert_eq!(region.node_count(), 1);
+        assert_eq!(region.port_count(), 0);
+    }
+
+    #[test]
+    fn simple_flat_region() -> Result<(), Box<dyn Error>> {
+        let mut graph = PortGraph::new();
+        let other = graph.add_node(42, 0);
+        let root = graph.add_node(1, 0);
+        let a = graph.add_node(1, 2);
+        let b = graph.add_node(0, 0);
+        let c = graph.add_node(0, 0);
+        graph.link_nodes(a, 0, other, 0)?;
+
+        let mut hierarchy = Hierarchy::new();
+        hierarchy.push_child(a, root)?;
+        hierarchy.push_child(b, root)?;
+        hierarchy.push_child(c, b)?;
+
+        let region = FlatRegion::new_flat_region(&graph, &hierarchy, root);
+
+        assert!(region.nodes_iter().eq([root, a, b]));
+        assert_eq!(region.node_count(), 3);
+        assert_eq!(region.port_count(), 4);
+        assert_eq!(region.link_count(), 0);
+
+        assert!(region.all_links(a).eq([]));
+        assert!(region.all_neighbours(a).eq([]));
+
+        Ok(())
+    }
+}

--- a/src/view/flat_region.rs
+++ b/src/view/flat_region.rs
@@ -1,4 +1,4 @@
-//! Views of a portgraph containing only the descendants of a node in a [`Hierarchy`].
+//! View of a portgraph containing only the children of a node in a [`Hierarchy`].
 
 use super::{LinkView, MultiView, PortView};
 use crate::{Direction, Hierarchy, NodeIndex, PortIndex, PortOffset};
@@ -23,7 +23,8 @@ impl<'a, G> FlatRegion<'a, G>
 where
     G: Clone,
 {
-    /// Create a new region view including all the descendants of the root node.
+    /// Create a new region view including only a root node and its direct
+    /// children in a [`Hierarchy`].
     pub fn new(graph: G, hierarchy: &'a Hierarchy, root: NodeIndex) -> Self {
         Self {
             graph,
@@ -69,6 +70,7 @@ where
 
     #[inline]
     fn is_empty(&self) -> bool {
+        // The region root is always present
         false
     }
 

--- a/src/view/region.rs
+++ b/src/view/region.rs
@@ -1,53 +1,44 @@
 //! Views of a portgraph containing only the descendants of a node in a [`Hierarchy`].
 
-use std::{cell::RefCell, collections::HashMap, iter};
+use delegate::delegate;
+use itertools::Either;
+use std::sync::RwLock;
+use std::{collections::HashMap, iter};
 
-use super::filter::NodeFiltered;
-use crate::{Hierarchy, NodeIndex};
-
-type RegionCallback<'g> = fn(NodeIndex, &RegionContext<'g>) -> bool;
+use super::{LinkView, MultiView, PortView};
+use crate::{Direction, Hierarchy, NodeIndex, PortIndex, PortOffset};
 
 /// View of a portgraph containing only a root node and its descendants in a
 /// [`Hierarchy`].
 ///
 /// For a view of a portgraph containing only the root and its direct children,
-/// see [`FlatRegion`]. Prefer using the flat variant when possible, as it is
+/// see [`crate::view::FlatRegion`]. Prefer using the flat variant when possible, as it is
 /// more efficient.
-///
-/// [`Region`] does not implement `Sync` as it uses a [`RefCell`] to cache the
-/// node filtering.
-pub type Region<'g, G> = NodeFiltered<G, RegionCallback<'g>, RegionContext<'g>>;
+#[derive(Debug)]
+pub struct Region<'g, G> {
+    /// The base graph
+    graph: G,
+    /// The root node of the region
+    region_root: NodeIndex,
+    /// The graph's hierarchy
+    hierarchy: &'g Hierarchy,
+    /// Cache of the result of the [`is_descendant`] check.
+    is_descendant: RwLock<HashMap<NodeIndex, bool>>,
+}
 
-impl<'a, G> Region<'a, G>
+impl<'g, G> Region<'g, G>
 where
     G: Clone,
 {
-    /// Create a new region view including all the descendants of the root node.
-    pub fn new_region(graph: G, hierarchy: &'a Hierarchy, root: NodeIndex) -> Self {
-        let region_filter: RegionCallback<'a> =
-            |node, context| node == context.root() || context.is_descendant(node);
-        Self::new_node_filtered(graph, region_filter, RegionContext::new(hierarchy, root))
-    }
-}
-
-/// Internal context used in the [`Region`] adaptor.
-#[derive(Debug, Clone)]
-pub struct RegionContext<'g> {
-    hierarchy: &'g Hierarchy,
-    root: NodeIndex,
-    /// Cache of the result of the [`is_descendant`] check.
-    is_descendant: RefCell<HashMap<NodeIndex, bool>>,
-}
-
-impl<'g> RegionContext<'g> {
-    /// Create a new [`RegionContext`].
-    pub fn new(hierarchy: &'g Hierarchy, root: NodeIndex) -> Self {
+    /// Create a new [`Region`] looking at a `root` node and its descendants in a [`Hierarchy`].
+    pub fn new(graph: G, hierarchy: &'g Hierarchy, root: NodeIndex) -> Self {
         let mut is_descendant = HashMap::new();
         is_descendant.insert(root, false);
         Self {
+            graph,
+            region_root: root,
             hierarchy,
-            root,
-            is_descendant: RefCell::new(is_descendant),
+            is_descendant: RwLock::new(is_descendant),
         }
     }
 
@@ -55,28 +46,44 @@ impl<'g> RegionContext<'g> {
     ///
     /// Caches the result of the check.
     pub fn is_descendant(&self, node: NodeIndex) -> bool {
-        if let Some(is_descendant) = self.is_descendant.borrow().get(&node) {
-            // We have already checked this node.
-            return *is_descendant;
+        if node == self.region_root {
+            return true;
         }
-        // Traverse the ancestors until we see a node we have already checked.
-        let cache = self.is_descendant.borrow();
-        let ancestors: Vec<_> = iter::successors(Some(node), |node| {
-            let parent = self.hierarchy.parent(*node)?;
-            match cache.contains_key(&parent) {
-                true => None,
-                false => Some(parent),
-            }
-        })
-        .collect();
-        let first_visited_ancestor = self.hierarchy.parent(*ancestors.last().unwrap());
-        let is_descendant = first_visited_ancestor == Some(self.root)
-            || first_visited_ancestor
-                .map_or(false, |ancestor| cache.get(&ancestor).copied().unwrap());
-        drop(cache);
 
-        // Update the cache for all the unvisited ancestors.
-        let mut cache_mut = self.is_descendant.borrow_mut();
+        // First, access the cache read-only to check if the node has already been visited.
+        // And compute whether the node is a descendant otherwise.
+        let (ancestors, is_descendant) = {
+            let cache = self
+                .is_descendant
+                .read()
+                .expect("The Region cache is poisoned.");
+
+            if let Some(is_descendant) = cache.get(&node) {
+                // We have already checked this node.
+                return *is_descendant;
+            }
+            // Traverse the ancestors until we see a node we have already checked, or the root.
+            let ancestors: Vec<_> = iter::successors(Some(node), |node| {
+                let parent = self.hierarchy.parent(*node)?;
+                match cache.contains_key(&parent) {
+                    true => None,
+                    false => Some(parent),
+                }
+            })
+            .collect();
+            let first_visited_ancestor = self.hierarchy.parent(*ancestors.last().unwrap());
+            let is_descendant = first_visited_ancestor == Some(self.region_root)
+                || first_visited_ancestor
+                    .map_or(false, |ancestor| cache.get(&ancestor).copied().unwrap());
+            drop(cache);
+            (ancestors, is_descendant)
+        };
+
+        // Now lock the cache for writing and update it with the new information.
+        let mut cache_mut = self
+            .is_descendant
+            .write()
+            .expect("The Region cache is poisoned.");
         for node in ancestors {
             cache_mut.insert(node, is_descendant);
         }
@@ -84,30 +91,208 @@ impl<'g> RegionContext<'g> {
     }
 
     /// Get the root node of the region.
-    pub fn root(&self) -> NodeIndex {
-        self.root
+    pub fn region_root(&self) -> NodeIndex {
+        self.region_root
     }
 }
 
-type FlatRegionContext<'g> = (&'g Hierarchy, NodeIndex);
-type FlatRegionCallback<'g> = fn(NodeIndex, &FlatRegionContext<'g>) -> bool;
-
-/// View of a portgraph containing only a root node and its direct children in a [`Hierarchy`].
-///
-/// For a view of all descendants, see [`Region`].
-pub type FlatRegion<'g, G> = NodeFiltered<G, FlatRegionCallback<'g>, FlatRegionContext<'g>>;
-
-impl<'a, G> FlatRegion<'a, G>
+impl<'g, G> Region<'g, G>
 where
-    G: Clone,
+    G: LinkView + Clone,
 {
-    /// Create a new region view including all the descendants of the root node.
-    pub fn new_flat_region(graph: G, hierarchy: &'a Hierarchy, root: NodeIndex) -> Self {
-        let region_filter: FlatRegionCallback<'a> = |node, context| {
-            let (hierarchy, root) = context;
-            node == *root || hierarchy.parent(node) == Some(*root)
+    /// Utility function to filter out links that are not in the subgraph.
+    #[inline(always)]
+    fn contains_link(&self, (from, to): (G::LinkEndpoint, G::LinkEndpoint)) -> bool {
+        self.contains_endpoint(from) && self.contains_endpoint(to)
+    }
+
+    /// Utility function to filter out link endpoints that are not in the subgraph.
+    #[inline(always)]
+    fn contains_endpoint(&self, e: G::LinkEndpoint) -> bool {
+        self.contains_port(e.into())
+    }
+}
+
+impl<'g, G: PartialEq> PartialEq for Region<'g, G> {
+    fn eq(&self, other: &Self) -> bool {
+        self.region_root == other.region_root
+            && self.graph == other.graph
+            && self.hierarchy == other.hierarchy
+    }
+}
+
+impl<'g, G: Clone> Clone for Region<'g, G> {
+    fn clone(&self) -> Self {
+        // Clone the cache if it is not currently locked.
+        // Otherwise, create a new empty cache.
+        let is_descendant = match self.is_descendant.try_read() {
+            Ok(cache) => cache.clone(),
+            Err(_) => HashMap::new(),
         };
-        Self::new_node_filtered(graph, region_filter, (hierarchy, root))
+        Self {
+            graph: self.graph.clone(),
+            region_root: self.region_root,
+            hierarchy: self.hierarchy,
+            is_descendant: RwLock::new(is_descendant),
+        }
+    }
+}
+
+impl<'g, G> PortView for Region<'g, G>
+where
+    G: PortView + Clone,
+{
+    #[inline(always)]
+    fn contains_node(&'_ self, node: NodeIndex) -> bool {
+        self.is_descendant(node)
+    }
+
+    #[inline(always)]
+    fn contains_port(&self, port: PortIndex) -> bool {
+        let Some(node) = self.graph.port_node(port) else {
+            return false;
+        };
+        self.contains_node(node)
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    fn node_count(&self) -> usize {
+        self.nodes_iter().count()
+    }
+
+    #[inline]
+    fn port_count(&self) -> usize {
+        self.ports_iter().count()
+    }
+
+    #[inline]
+    fn nodes_iter(&self) -> impl Iterator<Item = NodeIndex> + Clone {
+        self.hierarchy.descendants(self.region_root)
+    }
+
+    #[inline]
+    fn ports_iter(&self) -> impl Iterator<Item = PortIndex> + Clone {
+        self.nodes_iter().flat_map(|n| self.graph.all_ports(n))
+    }
+
+    delegate! {
+        to self.graph {
+            fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction>;
+            fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
+            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<crate::PortOffset>;
+            fn port_index(&self, node: NodeIndex, offset: crate::PortOffset) -> Option<PortIndex>;
+            fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex> + Clone;
+            fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone;
+            fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
+            fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
+            fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset> + Clone;
+            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone;
+            fn node_capacity(&self) -> usize;
+            fn port_capacity(&self) -> usize;
+            fn node_port_capacity(&self, node: NodeIndex) -> usize;
+        }
+    }
+}
+
+impl<'g, G> LinkView for Region<'g, G>
+where
+    G: LinkView + Clone,
+{
+    type LinkEndpoint = G::LinkEndpoint;
+
+    fn get_connections(
+        &self,
+        from: NodeIndex,
+        to: NodeIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
+        if self.is_descendant(from) && self.is_descendant(to) {
+            Either::Left(self.graph.get_connections(from, to))
+        } else {
+            Either::Right(std::iter::empty())
+        }
+    }
+
+    fn port_links(
+        &self,
+        port: PortIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
+        self.graph
+            .port_links(port)
+            .filter(|&lnk| self.contains_link(lnk))
+    }
+
+    fn links(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
+        self.graph
+            .links(node, direction)
+            .filter(|&lnk| self.contains_link(lnk))
+    }
+
+    fn all_links(
+        &self,
+        node: NodeIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
+        self.graph
+            .all_links(node)
+            .filter(|&lnk| self.contains_link(lnk))
+    }
+
+    fn neighbours(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = NodeIndex> + Clone {
+        self.graph
+            .neighbours(node, direction)
+            .filter(|&n| self.contains_node(n))
+    }
+
+    fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + Clone {
+        self.graph
+            .all_neighbours(node)
+            .filter(|&n| self.contains_node(n))
+    }
+
+    fn link_count(&self) -> usize {
+        self.nodes_iter()
+            .flat_map(|node| self.links(node, Direction::Outgoing))
+            .count()
+    }
+}
+
+impl<'g, G> MultiView for Region<'g, G>
+where
+    G: MultiView + Clone,
+{
+    fn subports(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = Self::LinkEndpoint> + Clone {
+        self.graph
+            .subports(node, direction)
+            .filter(|&p| self.contains_endpoint(p))
+    }
+
+    fn all_subports(&self, node: NodeIndex) -> impl Iterator<Item = Self::LinkEndpoint> + Clone {
+        self.graph
+            .all_subports(node)
+            .filter(|&p| self.contains_endpoint(p))
+    }
+
+    fn subport_link(&self, subport: Self::LinkEndpoint) -> Option<Self::LinkEndpoint> {
+        self.graph
+            .subport_link(subport)
+            .filter(|&p| self.contains_endpoint(p))
     }
 }
 
@@ -115,7 +300,7 @@ where
 mod test {
     use std::error::Error;
 
-    use crate::{Hierarchy, LinkMut, LinkView, PortGraph, PortMut, PortView};
+    use crate::{Hierarchy, LinkMut, PortGraph, PortMut};
 
     use super::*;
 
@@ -126,41 +311,9 @@ mod test {
 
         let hierarchy = Hierarchy::new();
 
-        let region = FlatRegion::new_flat_region(&graph, &hierarchy, root);
+        let region = Region::new(&graph, &hierarchy, root);
         assert_eq!(region.node_count(), 1);
         assert_eq!(region.port_count(), 0);
-
-        let region = Region::new_region(&graph, &hierarchy, root);
-        assert_eq!(region.node_count(), 1);
-        assert_eq!(region.port_count(), 0);
-    }
-
-    #[test]
-    fn simple_flat_region() -> Result<(), Box<dyn Error>> {
-        let mut graph = PortGraph::new();
-        let other = graph.add_node(42, 0);
-        let root = graph.add_node(1, 0);
-        let a = graph.add_node(1, 2);
-        let b = graph.add_node(0, 0);
-        let c = graph.add_node(0, 0);
-        graph.link_nodes(a, 0, other, 0)?;
-
-        let mut hierarchy = Hierarchy::new();
-        hierarchy.push_child(a, root)?;
-        hierarchy.push_child(b, root)?;
-        hierarchy.push_child(c, b)?;
-
-        let region = FlatRegion::new_flat_region(&graph, &hierarchy, root);
-
-        assert!(region.nodes_iter().eq([root, a, b]));
-        assert_eq!(region.node_count(), 3);
-        assert_eq!(region.port_count(), 4);
-        assert_eq!(region.link_count(), 0);
-
-        assert!(region.all_links(a).eq([]));
-        assert!(region.all_neighbours(a).eq([]));
-
-        Ok(())
     }
 
     #[test]
@@ -178,7 +331,7 @@ mod test {
         hierarchy.push_child(b, root)?;
         hierarchy.push_child(c, b)?;
 
-        let region = Region::new_region(&graph, &hierarchy, root);
+        let region = Region::new(&graph, &hierarchy, root);
 
         assert!(
             region.nodes_iter().eq([root, a, b, c]),

--- a/src/view/region.rs
+++ b/src/view/region.rs
@@ -1,4 +1,4 @@
-//! Views of a portgraph containing only the descendants of a node in a [`Hierarchy`].
+//! View of a portgraph containing only the descendants of a node in a [`Hierarchy`].
 
 use delegate::delegate;
 use itertools::Either;
@@ -30,7 +30,8 @@ impl<'g, G> Region<'g, G>
 where
     G: Clone,
 {
-    /// Create a new [`Region`] looking at a `root` node and its descendants in a [`Hierarchy`].
+    /// Create a new [`Region`] looking at a `root` node and its descendants in
+    /// a [`Hierarchy`].
     pub fn new(graph: G, hierarchy: &'g Hierarchy, root: NodeIndex) -> Self {
         let mut is_descendant = HashMap::new();
         is_descendant.insert(root, false);
@@ -75,6 +76,9 @@ where
             let is_descendant = first_visited_ancestor == Some(self.region_root)
                 || first_visited_ancestor
                     .map_or(false, |ancestor| cache.get(&ancestor).copied().unwrap());
+
+            // The read lock is dropped here, before we reacquire it for writing
+            // the computed values.
             drop(cache);
             (ancestors, is_descendant)
         };
@@ -157,6 +161,7 @@ where
 
     #[inline]
     fn is_empty(&self) -> bool {
+        // The region root is always present
         false
     }
 


### PR DESCRIPTION
Followup to #157. Avoids using `FilteredGraph` for the implementation of `Region` and `FlatRegion` and instead implements the graph traits manually to avoid doing full-graph traversals when we can do better/faster checks.

Closes #159. Closes #145 (BFS rather than DFS). Closes #135.

BREAKING CHANGE:  `Region` and `FlatRegion` are no longer aliases of FilteredGraph