### PR TITLE
fix: Hierarchy descendants return root siblings

### DIFF
--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -399,8 +399,7 @@ impl Hierarchy {
     pub fn descendants(&self, node: NodeIndex) -> Descendants<'_> {
         Descendants {
             layout: self,
-            child_queue: VecDeque::from(vec![node]),
-            root: node,
+            node_queue: NextStates::Root(node),
         }
     }
 
@@ -635,9 +634,27 @@ pub struct Descendants<'a> {
     ///
     /// For each region, we point to a child node that has not been visited yet.
     /// When a region is visited, we move to the next child node and queue its children region at the end of the queue.
-    child_queue: VecDeque<NodeIndex>,
-    /// The root node we are iterating over.
-    root: NodeIndex,
+    node_queue: NextStates,
+}
+
+/// A queue of nodes to visit next in the [`Descendants`] iterator.
+#[derive(Clone, Debug)]
+enum NextStates {
+    /// The iterator hasn't been queried yet. It stores only the root node.
+    Root(NodeIndex),
+    /// We are in the process of exploring the descendants.
+    /// This queue does **not** include the root node.
+    Descendants(VecDeque<NodeIndex>),
+}
+
+impl NextStates {
+    /// Returns the number of nodes currently in the queue.
+    fn len(&self) -> usize {
+        match self {
+            Self::Root(_) => 1,
+            Self::Descendants(queue) => queue.len(),
+        }
+    }
 }
 
 impl Default for Descendants<'static> {
@@ -645,8 +662,7 @@ impl Default for Descendants<'static> {
         static HIERARCHY: Hierarchy = Hierarchy::new();
         Self {
             layout: &HIERARCHY,
-            child_queue: VecDeque::new(),
-            root: NodeIndex::new(0),
+            node_queue: NextStates::Descendants(VecDeque::new()),
         }
     }
 }
@@ -655,19 +671,27 @@ impl Iterator for Descendants<'_> {
     type Item = NodeIndex;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // The next element is always the first node in the queue.
-        let next = self.child_queue.pop_front()?;
+        if let NextStates::Root(root) = &self.node_queue {
+            let root = *root;
+            self.node_queue = NextStates::Descendants(VecDeque::from_iter(self.layout.first(root)));
+            return Some(root);
+        };
+        let NextStates::Descendants(queue) = &mut self.node_queue else {
+            unreachable!()
+        };
 
-        // Check if the node had a next sibling, and add it to the front of queue.
-        if next != self.root {
-            if let Some(next_sibling) = self.layout.next(next) {
-                self.child_queue.push_front(next_sibling);
-            }
+        // The next element is always the first node in the queue.
+        let next = queue.pop_front()?;
+
+        // Check if the node had a next sibling and add it to the front of
+        // queue.
+        if let Some(next_sibling) = self.layout.next(next) {
+            queue.push_front(next_sibling);
         }
 
         // Now add the children region of `next` to the end of the queue.
         if let Some(child) = self.layout.first(next) {
-            self.child_queue.push_back(child);
+            queue.push_back(child);
         }
 
         Some(next)
@@ -675,7 +699,7 @@ impl Iterator for Descendants<'_> {
 
     #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.child_queue.len(), None)
+        (self.node_queue.len(), None)
     }
 }
 


### PR DESCRIPTION
Closes #177 