### PR TITLE
refactor: simplify port_links, RFC on remove helpers (post-RPITIT TLC)

### DIFF
--- a/src/multiportgraph.rs
+++ b/src/multiportgraph.rs
@@ -265,21 +265,47 @@ impl LinkView for MultiPortGraph {
         self.graph.link_count() - self.copy_node_count
     }
 
-    delegate! {
-        to self {
-            #[call(_get_connections)]
-            fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
-            #[call(_port_links)]
-            fn port_links(&self, port: PortIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
-            #[call(_links)]
-            fn links(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
-            #[call(_all_links)]
-            fn all_links(&self, node: NodeIndex) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone;
-            #[call(_neighbours)]
-            fn neighbours(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = NodeIndex> + Clone;
-            #[call(_all_neighbours)]
-            fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + Clone;
-        }
+    fn get_connections(
+        &self,
+        from: NodeIndex,
+        to: NodeIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
+        NodeConnections::new(self, to, self.output_links(from))
+    }
+
+    fn port_links(
+        &self,
+        port: PortIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
+        PortLinks::new(self, port)
+    }
+
+    fn links(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
+        NodeLinks::new(self, self.graph._ports(node, direction), 0..0)
+    }
+
+    fn all_links(
+        &self,
+        node: NodeIndex,
+    ) -> impl Iterator<Item = (Self::LinkEndpoint, Self::LinkEndpoint)> + Clone {
+        let output_ports = self.graph.node_outgoing_ports(node);
+        NodeLinks::new(self, self.graph._all_ports(node), output_ports)
+    }
+
+    fn neighbours(
+        &self,
+        node: NodeIndex,
+        direction: Direction,
+    ) -> impl Iterator<Item = NodeIndex> + Clone {
+        Neighbours::new(self, self._subports(node, direction), node, false)
+    }
+
+    fn all_neighbours(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + Clone {
+        Neighbours::new(self, self._all_subports(node), node, true)
     }
 }
 

--- a/src/portgraph.rs
+++ b/src/portgraph.rs
@@ -712,14 +712,9 @@ impl LinkView for PortGraph {
 
     fn port_links(&self, port: PortIndex) -> impl Iterator<Item = (PortIndex, PortIndex)> + Clone {
         self.port_meta_valid(port).unwrap();
-        match self.port_link[port.index()] {
-            Some(link) => std::iter::once((port, link)),
-            None => {
-                let mut iter = std::iter::once((port, port));
-                iter.next();
-                iter
-            }
-        }
+        self.port_link[port.index()]
+            .map(|link| (port, link))
+            .into_iter()
     }
 
     #[inline]


### PR DESCRIPTION
We don't really need the various helpers typed as returning `NodeConnections` etc. now, but removing them is a bit of a PITA because some of these structs contain each other - so I haven't done all of them, thought I'd RFC first...