### PR TITLE
feat: Node style attributes in render options

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -100,15 +100,14 @@ impl NodeStyle {
 
     /// Set the presentation attributes of the node.
     pub fn with_attrs(mut self, attrs: PresentationStyle) -> Self {
-        match &mut self {
-            Self::Boxed { attrs: a, .. } => *a = attrs,
-            _ => {}
+        if let Self::Boxed { attrs: a, .. } = &mut self {
+            *a = attrs
         }
         self
     }
 
     /// Returns the presentation attributes of the node.
-    pub const fn attrs(&self) -> &PresentationStyle {
+    pub fn attrs(&self) -> &PresentationStyle {
         static DEFAULT: PresentationStyle = PresentationStyle::new();
         match self {
             Self::Boxed { attrs, .. } => attrs,
@@ -234,6 +233,7 @@ impl EdgeStyle {
 }
 
 #[cfg(test)]
+#[allow(clippy::type_complexity)]
 mod test {
     use std::fmt::Display;
     use std::sync::OnceLock;

--- a/src/render.rs
+++ b/src/render.rs
@@ -66,7 +66,7 @@ pub enum NodeStyle {
     /// Ignore the node. No edges will be connected to it.
     Hidden,
     /// Draw a box with the label inside.
-    #[deprecated(since = "0.14.1", note = "Use `Box` instead")]
+    #[deprecated(since = "0.14.1", note = "Use `Boxed` instead")]
     Box(String),
     /// Draw a box with label inside.
     #[non_exhaustive]

--- a/src/render/dot.rs
+++ b/src/render/dot.rs
@@ -141,9 +141,9 @@ where
 
             let node_str = String::new()
                 + &node.index().to_string()
-                + "[shape=plain "
+                + " [shape=plain "
                 + &encode_presentation_attrs(&attrs)
-                + " label=<"
+                + "label=<"
                 + "<table border=\"1\">"
                 + &inputs_row
                 + &label_row
@@ -302,16 +302,16 @@ struct PortCellStrings {
 pub fn encode_presentation_attrs(attrs: &PresentationStyle) -> String {
     let mut result = Vec::new();
     if let Some(color) = &attrs.color {
-        result.push(format!("fontcolor=\'{color}'\""));
+        result.push(format!("fontcolor=\"{color}\" "));
     }
     if let Some(fill) = &attrs.fill {
-        result.push(format!("fillcolor=\'{fill}'\""));
+        result.push(format!("fillcolor=\"{fill}\" "));
     }
     if let Some(stroke) = &attrs.stroke {
-        result.push(format!("color=\'{stroke}'\""));
+        result.push(format!("color=\"{stroke}\" "));
     }
     if let Some(stroke_width) = &attrs.stroke_width {
-        result.push(format!("penwidth=\'{stroke_width}'\""));
+        result.push(format!("penwidth=\"{stroke_width}\" "));
     }
-    result.into_iter().join(" ")
+    result.into_iter().join("")
 }

--- a/src/render/mermaid.rs
+++ b/src/render/mermaid.rs
@@ -363,17 +363,13 @@ impl<'g, G: LinkView> MermaidBuilder<'g, G> {
                 "subgraph ",
                 id.as_ref(),
                 " [",
-                &encode_label(&id, &label),
+                &encode_label(&id, label),
                 "]",
             ]),
             #[allow(deprecated)]
-            NodeStyle::Box(lbl) => self.push_strings(&[
-                "subgraph ",
-                id.as_ref(),
-                " [",
-                &encode_label(&id, &lbl),
-                "]",
-            ]),
+            NodeStyle::Box(lbl) => {
+                self.push_strings(&["subgraph ", id.as_ref(), " [", &encode_label(&id, lbl), "]"])
+            }
         }
         self.indent += 1;
         self.push_line("direction LR");
@@ -383,7 +379,7 @@ impl<'g, G: LinkView> MermaidBuilder<'g, G> {
                 "style ",
                 id.as_ref(),
                 " ",
-                &encode_presentation_attrs(&style.attrs()),
+                &encode_presentation_attrs(style.attrs()),
             ]);
         }
     }

--- a/src/snapshots/portgraph__render__test__hierarchy__dot.snap
+++ b/src/snapshots/portgraph__render__test__hierarchy__dot.snap
@@ -3,7 +3,7 @@ source: src/render.rs
 expression: dot
 ---
 digraph {
-0 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="2" cellpadding="1" >0</td><td port="in1" align="text" colspan="2" cellpadding="1" >1</td><td port="in2" align="text" colspan="2" cellpadding="1" >2</td></tr><tr><td align="text" border="0" colspan="6">0</td></tr><tr><td port="out0" align="text" colspan="3" cellpadding="1" >0</td><td port="out1" align="text" colspan="3" cellpadding="1" >1</td></tr></table>>]
+0 [shape=plain fontcolor="#f00" fillcolor="#0f0" color="#00f" penwidth="4px" label=<<table border="1"><tr><td port="in0" align="text" colspan="2" cellpadding="1" >0</td><td port="in1" align="text" colspan="2" cellpadding="1" >1</td><td port="in2" align="text" colspan="2" cellpadding="1" >2</td></tr><tr><td align="text" border="0" colspan="6">root</td></tr><tr><td port="out0" align="text" colspan="3" cellpadding="1" >0</td><td port="out1" align="text" colspan="3" cellpadding="1" >1</td></tr></table>>]
 1 [shape=plain label=<<table border="1"><tr><td align="text" border="0" colspan="1">1</td></tr><tr><td port="out0" align="text" colspan="1" cellpadding="1" >0</td></tr></table>>]
 1:out0 -> 2:in0 [style=""]
 2 [shape=plain label=<<table border="1"><tr><td port="in0" align="text" colspan="1" cellpadding="1" >0</td></tr><tr><td align="text" border="0" colspan="1">2</td></tr></table>>]

--- a/src/snapshots/portgraph__render__test__hierarchy__mermaid.snap
+++ b/src/snapshots/portgraph__render__test__hierarchy__mermaid.snap
@@ -3,9 +3,10 @@ source: src/render.rs
 expression: mermaid
 ---
 graph LR
-    subgraph 0 [0]
+    subgraph 0 ["root"]
         direction LR
-        1[1]
-        2[2]
+        style 0 color:#f00,fill:#0f0,stroke:#00f,stroke-width:4px
+        1["1"]
+        2["2"]
         1-->2
     end


### PR DESCRIPTION
Lets us specify the node colour / stroke when rendering mermaid or dot graphs.