### PR TITLE
feat!: convert `PortOffset` in to struct with private fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ pub use crate::weights::Weights;
 /// Direction of a port.
 #[cfg_attr(feature = "pyo3", pyclass(eq, eq_int))]
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Direction {
     /// Input to a node.
     #[default]
@@ -311,19 +312,12 @@ pub struct IndexError {
     index: usize,
 }
 
-#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize), serde(transparent))]
-/// Index of a port offset within a node.
-pub struct PortOffsetIndex(u16);
-
 /// Port offset in a node
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-pub enum PortOffset {
-    /// Input to a node.
-    Incoming(PortOffsetIndex),
-    /// Output from a node.
-    Outgoing(PortOffsetIndex),
+pub struct PortOffset {
+    index: u16,
+    direction: Direction,
 }
 
 impl PortOffset {
@@ -339,39 +333,35 @@ impl PortOffset {
     /// Creates a new incoming port offset.
     #[inline(always)]
     pub fn new_incoming(offset: usize) -> Self {
-        PortOffset::Incoming(PortOffsetIndex(
-            offset
+        Self {
+            index: offset
                 .try_into()
                 .expect("The offset must be less than 2^16."),
-        ))
+            direction: Direction::Incoming,
+        }
     }
 
     /// Creates a new outgoing port offset.
     #[inline(always)]
     pub fn new_outgoing(offset: usize) -> Self {
-        PortOffset::Outgoing(PortOffsetIndex(
-            offset
+        Self {
+            index: offset
                 .try_into()
                 .expect("The offset must be less than 2^16."),
-        ))
+            direction: Direction::Outgoing,
+        }
     }
 
     /// Returns the direction of the port.
     #[inline(always)]
     pub fn direction(self) -> Direction {
-        match self {
-            PortOffset::Incoming(_) => Direction::Incoming,
-            PortOffset::Outgoing(_) => Direction::Outgoing,
-        }
+        self.direction
     }
 
     /// Returns the offset of the port.
     #[inline(always)]
     pub fn index(self) -> usize {
-        match self {
-            PortOffset::Incoming(offset) => offset.0 as usize,
-            PortOffset::Outgoing(offset) => offset.0 as usize,
-        }
+        self.index as usize
     }
 
     /// Returns the opposite port offset.
@@ -380,9 +370,9 @@ impl PortOffset {
     /// vice versa.
     #[inline(always)]
     pub fn opposite(&self) -> Self {
-        match *self {
-            PortOffset::Incoming(idx) => PortOffset::Outgoing(idx),
-            PortOffset::Outgoing(idx) => PortOffset::Incoming(idx),
+        Self {
+            index: self.index,
+            direction: self.direction.reverse(),
         }
     }
 }
@@ -395,9 +385,9 @@ impl Default for PortOffset {
 
 impl std::fmt::Debug for PortOffset {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PortOffset::Incoming(idx) => write!(f, "Incoming({})", idx.0),
-            PortOffset::Outgoing(idx) => write!(f, "Outgoing({})", idx.0),
+        match self.direction {
+            Direction::Incoming => write!(f, "Incoming({})", self.index),
+            Direction::Outgoing => write!(f, "Outgoing({})", self.index),
         }
     }
 }

--- a/src/proptest.rs
+++ b/src/proptest.rs
@@ -4,7 +4,9 @@
 //! returns strategies that generate random portgraphs.
 use std::collections::{BTreeMap, HashSet};
 
-use crate::{LinkMut, MultiPortGraph, NodeIndex, PortGraph, PortMut, PortOffset, PortView};
+use crate::{
+    Direction, LinkMut, MultiPortGraph, NodeIndex, PortGraph, PortMut, PortOffset, PortView,
+};
 use proptest::prelude::*;
 
 #[derive(Debug, Clone, Copy)]
@@ -110,10 +112,10 @@ fn graph_from_edges<G: PortMut + LinkMut + Default>(edges: &[Edge]) -> G {
     let mut map_vertices = BTreeMap::new();
     let mut in_port_counts = BTreeMap::new();
     let mut out_port_counts = BTreeMap::new();
-    let mut add_port = |v, p| {
-        let (max, port) = match p {
-            PortOffset::Incoming(_) => (in_port_counts.entry(v).or_insert(0), p.index()),
-            PortOffset::Outgoing(_) => (out_port_counts.entry(v).or_insert(0), p.index()),
+    let mut add_port = |v, p: PortOffset| {
+        let (max, port) = match p.direction() {
+            Direction::Incoming => (in_port_counts.entry(v).or_insert(0), p.index()),
+            Direction::Outgoing => (out_port_counts.entry(v).or_insert(0), p.index()),
         };
         *max = (*max).max(port + 1);
     };


### PR DESCRIPTION
BREAKING CHANGE: `PortOffset` is no longer an enum but a struct with private fields. Match on `offset.direction()` instead.