### PR TITLE
ci: Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,20 @@ updates:
     commit-message:
       # Use a conventional commit tag
       prefix: "chore(deps)"
+    groups:
+      dev:
+        dependency-type: "development"
+        update-types: ["patch", "minor"]
+      patch:
+        update-types: ["patch"]
+      minor:
+        update-types: ["minor"]
+      # Major updates still generate individual PRs
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      # Use a conventional commit tag
+      prefix: "ci(deps)"


### PR DESCRIPTION
Make dependabot group patch and minor dependency updates, so we don't get spammed
<img width="739" alt="image" src="https://github.com/user-attachments/assets/aabca95b-8bd4-4190-aa45-1e731ddeec71" />
