### PR TITLE
feat!: Make PortGraph generic on node and port types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,7 @@ dependencies = [
  "iai-callgrind",
  "insta",
  "itertools 0.14.0",
+ "num-traits",
  "petgraph",
  "proptest",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ itertools = "0.14.0"
 pyo3 = { version = ">= 0.23, < 0.26", optional = true, features = [
     "multiple-pymethods",
 ] }
+num-traits = "0.2.19"
 
 [features]
 pyo3 = ["dep:pyo3"]

--- a/src/algorithms/convex.rs
+++ b/src/algorithms/convex.rs
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn dangling_input() {
-        let mut g = PortGraph::new();
+        let mut g: PortGraph = PortGraph::new();
         let n = g.add_node(1, 1);
         let checker = TopoConvexChecker::new(&g);
         assert!(checker.is_node_convex([n]));
@@ -269,7 +269,7 @@ mod tests {
 
     #[test]
     fn disconnected_graph() {
-        let mut g = PortGraph::new();
+        let mut g: PortGraph = PortGraph::new();
         let n = g.add_node(1, 1);
         g.add_node(1, 1);
         let checker = TopoConvexChecker::new(&g);

--- a/src/algorithms/toposort.rs
+++ b/src/algorithms/toposort.rs
@@ -21,7 +21,7 @@ use std::{collections::VecDeque, fmt::Debug, iter::FusedIterator};
 /// ```
 /// # use ::portgraph::algorithms::*;
 /// # use ::portgraph::*;
-/// let mut graph = PortGraph::new();
+/// let mut graph: PortGraph = PortGraph::new();
 /// let node_a = graph.add_node(2, 2);
 /// let node_b = graph.add_node(2, 2);
 /// graph.link_nodes(node_a, 0, node_b, 0).unwrap();
@@ -67,7 +67,7 @@ where
 /// ```
 /// # use ::portgraph::algorithms::*;
 /// # use ::portgraph::*;
-/// let mut graph = PortGraph::new();
+/// let mut graph: PortGraph = PortGraph::new();
 /// let node_a = graph.add_node(2, 2);
 /// let node_b = graph.add_node(2, 2);
 /// let node_c = graph.add_node(2, 2);
@@ -332,7 +332,7 @@ mod test {
 
     #[test]
     fn small_toposort() {
-        let mut graph = PortGraph::new();
+        let mut graph: PortGraph = PortGraph::new();
         let node_a = graph.add_node(2, 3);
         let node_b = graph.add_node(3, 2);
         let node_c = graph.add_node(3, 2);

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -14,7 +14,7 @@
 //!
 //! ```
 //! # use ::portgraph::*;
-//! let mut graph = PortGraph::new();
+//! let mut graph: PortGraph = PortGraph::new();
 //! let mut hierarchy = Hierarchy::new();
 //!
 //! let parent = graph.add_node(0, 0);
@@ -967,7 +967,7 @@ mod test {
 
     #[test]
     fn test_graph_compact() {
-        let mut graph = PortGraph::new();
+        let mut graph: PortGraph = PortGraph::new();
         let mut hierarchy = Hierarchy::new();
 
         let parent = graph.add_node(0, 0);

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,6 +1,7 @@
 //! Index types for nodes and ports.
 
-use delegate::delegate;
+use std::ops;
+
 use thiserror::Error;
 
 #[cfg(feature = "pyo3")]
@@ -11,87 +12,25 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::Direction;
 
-/// Index type that can be used to index nodes and ports.
-///
-/// Currently, implementations are provided for `usize`, `u64`, `u32`, `u16`,
-/// and `u8`. Choose the bit width that suits your needs.
-pub trait Index: Copy {
-    const MAX: usize;
-
-    fn try_from_usize(index: usize) -> Result<Self, IndexError>;
-
-    fn to_usize(self) -> usize;
-
-    fn set_msb(self) -> Self;
-
-    fn unset_msb(self) -> Self;
-
-    fn msb(self) -> bool;
-
-    fn flip_msb(self) -> Self {
-        if self.msb() {
-            self.unset_msb()
-        } else {
-            self.set_msb()
-        }
-    }
-}
-
-macro_rules! impl_index_for {
-    ($ty:ty) => {
-        impl Index for $ty {
-            const MAX: usize = <$ty>::MAX as usize;
-
-            fn try_from_usize(index: usize) -> Result<Self, IndexError> {
-                if index > <Self as Index>::MAX {
-                    Err(IndexError { index })
-                } else {
-                    Ok(index as Self)
-                }
-            }
-
-            fn to_usize(self) -> usize {
-                self as usize
-            }
-
-            fn set_msb(self) -> Self {
-                self | (1 << (<$ty>::BITS - 1))
-            }
-
-            fn unset_msb(self) -> Self {
-                self & !(1 << (<$ty>::BITS - 1))
-            }
-
-            fn msb(self) -> bool {
-                self & (1 << (<$ty>::BITS - 1)) != 0
-            }
-        }
-    };
-}
-
-impl_index_for!(usize);
-impl_index_for!(u64);
-impl_index_for!(u32);
-impl_index_for!(u16);
-impl_index_for!(u8);
-
 /// Index of a node within a `PortGraph`.
 ///
-/// For an index type with n bits, the index value will be restricted to at
+/// For a bit field with n bits, the index value will be restricted to at
 /// most `2^n - 1` . The all null value is reserved for null-pointer optimisation.
+///
+/// Use with one of `usize`, `u64`, `u32`, `u16` and `u8`. Choose the bit width
+/// that suits your needs.
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(
     feature = "serde",
     serde(bound(
-        serialize = "T: Serialize + Index",
-        deserialize = "T: Deserialize<'de> + Index"
+        serialize = "U: Serialize + Unsigned",
+        deserialize = "U: Deserialize<'de> + Unsigned"
     ))
 )]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "pyo3", derive(IntoPyObject))]
-pub struct NodeIndex<T>(ShiftedIndex<T>);
+pub struct NodeIndex<U = u32>(BitField<U>);
 
 /// Index of a port within a `PortGraph`.
 ///
@@ -100,23 +39,24 @@ pub struct NodeIndex<T>(ShiftedIndex<T>);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(
     feature = "serde",
     serde(bound(
-        serialize = "T: Serialize + Index",
-        deserialize = "T: Deserialize<'de> + Index"
+        serialize = "U: Serialize + Unsigned",
+        deserialize = "U: Deserialize<'de> + Unsigned"
     ))
 )]
 #[cfg_attr(feature = "pyo3", derive(IntoPyObject))]
-pub struct PortIndex<T>(ShiftedIndex<T>);
+pub struct PortIndex<U = u32>(BitField<U>);
 
 // Wraps the ShiftedIndex API for NodeIndex and PortIndex.
 macro_rules! index_impls {
     ($name:ident) => {
-        impl<T: Index> $name<T> {
+        impl<U: Unsigned> $name<U> {
             /// Maximum allowed index.
-            const MAX: usize = ShiftedIndex::<T>::MAX;
+            pub fn max_index() -> usize {
+                BitField::<U>::max_index()
+            }
 
             /// Creates a new index from a `usize`.
             ///
@@ -125,34 +65,32 @@ macro_rules! index_impls {
             /// Panics if the index is greater than `Self::MAX`.
             #[inline]
             pub fn new(index: usize) -> Self {
-                Self(ShiftedIndex::new(index))
+                Self(BitField::new(index, false))
             }
 
-            delegate! {
-                to self.0 {
-                    /// Returns the index as a `T`.
-                    pub fn index(&self) -> usize;
-                }
+            /// Returns the index as a `T`.
+            pub fn index(&self) -> usize {
+                self.0.index().expect("invalid index")
             }
         }
 
-        impl<T: Index> TryFrom<usize> for $name<T> {
+        impl<U: Unsigned> TryFrom<usize> for $name<U> {
             type Error = IndexError;
 
             #[inline]
             fn try_from(index: usize) -> Result<Self, Self::Error> {
-                ShiftedIndex::try_from(index).map(Self)
+                BitField::try_from(index).map(Self)
             }
         }
 
-        impl<T: Index> From<$name<T>> for usize {
+        impl<U: Unsigned> From<$name<U>> for usize {
             #[inline]
-            fn from(index: $name<T>) -> Self {
+            fn from(index: $name<U>) -> Self {
                 Self::from(index.0)
             }
         }
 
-        impl<T: Index> std::fmt::Debug for $name<T> {
+        impl<U: Unsigned> std::fmt::Debug for $name<U> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 // avoid unnecessary newlines in alternate mode
                 write!(f, concat!(stringify!($name), "({})"), self.index())
@@ -164,7 +102,7 @@ macro_rules! index_impls {
 index_impls!(NodeIndex);
 index_impls!(PortIndex);
 
-impl<T: Index> Default for PortIndex<T> {
+impl<U: Unsigned> Default for PortIndex<U> {
     fn default() -> Self {
         PortIndex::new(0)
     }
@@ -175,48 +113,46 @@ impl<T: Index> Default for PortIndex<T> {
 /// For an index type with n bits, the index value will be restricted to at
 /// most `2^(n-1)` . The most significant bit is reserved to store the direction
 /// of the offset, see [`PortOffset::direction`].
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-pub struct PortOffset<T>(T);
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "U: Serialize + Unsigned",
+        deserialize = "U: Deserialize<'de> + Unsigned"
+    ))
+)]
+pub struct PortOffset<U = u16>(BitField<U>);
 
-impl<T: Index> PortOffset<T> {
+impl<U: Unsigned> PortOffset<U> {
     /// Maximum allowed offset. One bit is reserved for the direction.
-    const MAX: usize = T::MAX >> 1;
+    pub fn max_offset() -> usize {
+        BitField::<U>::max_index()
+    }
 
     /// Creates a new port offset.
     #[inline(always)]
     pub fn new(direction: Direction, offset: usize) -> Self {
-        match direction {
-            Direction::Incoming => Self::new_incoming(offset),
-            Direction::Outgoing => Self::new_outgoing(offset),
-        }
+        Self(BitField::new(offset, direction == Direction::Outgoing))
     }
 
     /// Creates a new incoming port offset.
     #[inline(always)]
     pub fn new_incoming(offset: usize) -> Self {
-        if offset > Self::MAX {
-            panic!("the offset is too large.")
-        }
-        let offset = T::try_from_usize(offset).expect("smaller than allowed MAX value");
-        Self(offset)
+        Self::new(Direction::Incoming, offset)
     }
 
     /// Creates a new outgoing port offset.
     #[inline(always)]
     pub fn new_outgoing(offset: usize) -> Self {
-        if offset > Self::MAX {
-            panic!("the offset is too large.")
-        }
-        let offset = T::try_from_usize(offset).expect("smaller than allowed MAX value");
-        offset.set_msb(); // mark that this is an outgoing port
-        Self(offset)
+        Self::new(Direction::Outgoing, offset)
     }
 
     /// Returns the direction of the port.
     #[inline(always)]
     pub fn direction(self) -> Direction {
-        if self.0.msb() {
+        if self.0.bit_flag().expect("invalid port offset") {
             Direction::Outgoing
         } else {
             Direction::Incoming
@@ -226,8 +162,7 @@ impl<T: Index> PortOffset<T> {
     /// Returns the offset of the port.
     #[inline(always)]
     pub fn index(self) -> usize {
-        let offset = self.0;
-        offset.unset_msb().to_usize()
+        self.0.index().expect("invalid port offset")
     }
 
     /// Returns the opposite port offset.
@@ -236,17 +171,17 @@ impl<T: Index> PortOffset<T> {
     /// vice versa.
     #[inline(always)]
     pub fn opposite(&self) -> Self {
-        Self(self.0.flip_msb())
+        Self(self.0.flip_bit_flag())
     }
 }
 
-impl<T: Index> Default for PortOffset<T> {
+impl<U: Unsigned> Default for PortOffset<U> {
     fn default() -> Self {
         PortOffset::new_outgoing(0)
     }
 }
 
-impl<T: Index> std::fmt::Debug for PortOffset<T> {
+impl<U: Unsigned> std::fmt::Debug for PortOffset<U> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.direction() {
             Direction::Incoming => write!(f, "Incoming({})", self.index()),
@@ -255,81 +190,196 @@ impl<T: Index> std::fmt::Debug for PortOffset<T> {
     }
 }
 
-/// An index, stored as shifted by one.
+/// Fields of bits that can be used for node and port indices. Stores an index
+/// and a bit flag.
 ///
-/// The range of the index is [0, MAX - 1], but is represented internally by the
-/// interval [1, MAX]. This allows the *null pointer optimization* so that the
-/// compiler can represent `Option<ShiftedIndex<T>>` in as much space as `T` by
-/// itself.
+/// For a field of n bits, the range of the index is [0, 2^(n-1) - 1]. This
+/// saves one value (U::MAX) to flag an invalid/unset index and one bit for
+/// extra information, e.g. Direction.
+///
+/// Use with one of `usize`, `u64`, `u32`, `u16` and `u8`. Choose the bit width
+/// that suits your needs.
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "pyo3", derive(IntoPyObject))]
-struct ShiftedIndex<T>(T);
+pub struct BitField<U>(U);
 
-impl<T: Index> ShiftedIndex<T> {
-    /// Maximum allowed index.
-    const MAX: usize = T::MAX - 1;
+/// Trait for unsigned integer types.
+///
+/// This is a wrapper around the `num_traits::Unsigned`, along with additional
+/// bit logic traits that are typically implemented for unsigned integer types.
+///
+/// Implementations are provided for `u8`, `u16`, `u32`, `u64`, and `usize`.
+pub trait Unsigned:
+    Copy
+    + std::fmt::Debug
+    + Ord
+    + num_traits::Unsigned
+    + num_traits::Bounded
+    + num_traits::ToPrimitive
+    + num_traits::FromPrimitive
+    + ops::Shr<u8, Output = Self>
+    + ops::Not<Output = Self>
+    + ops::BitAnd<Output = Self>
+    + ops::BitOr<Output = Self>
+    + ops::BitXor<Output = Self>
+{
+}
 
-    /// Returns the index as a `T`.
-    pub fn index(&self) -> usize {
-        self.0.to_usize() - 1
+impl Unsigned for u8 {}
+impl Unsigned for u16 {}
+impl Unsigned for u32 {}
+impl Unsigned for u64 {}
+impl Unsigned for usize {}
+// leave out u128 on purpose (casts to usize will panic)
+
+impl<U: Unsigned> BitField<U> {
+    /// Create a new bit field with the given index and bit flag.
+    fn new(index: usize, bit_flag: bool) -> Self {
+        let u = U::from_usize(index).expect("index too large");
+        let ret = Self(u);
+        if bit_flag {
+            ret.set_bit_flag()
+        } else {
+            ret
+        }
     }
 
-    /// Creates a new node index from a `usize`.
+    /// Create a new unset bit field
+    fn new_none() -> Self {
+        Self(U::max_value())
+    }
+
+    /// Maximum allowed index.
+    fn max_index() -> usize {
+        (U::max_value()
+            .to_usize()
+            .expect("max value larger than usize")
+            >> 1)
+            - 1
+    }
+
+    /// Return the index stored in the bit field as a `usize`.
     ///
-    /// # Panics
-    ///
-    /// Panics if the index is greater than `Self::MAX`.
-    #[inline]
-    pub fn new(index: usize) -> Self {
-        if index > Self::MAX {
-            panic!("the index is too large.")
+    /// Return `None` if the bit field is unset.
+    fn index(self) -> Option<usize> {
+        if self.is_none() {
+            return None;
         }
-        debug_assert!(index + 1 <= T::MAX);
-        let index = T::try_from_usize(index + 1).expect("smaller than allowed MAX value");
-        Self(index)
+        let index = self.0 & !Self::msb_mask();
+        Some(index.to_usize().expect("index too large"))
+    }
+
+    /// Set the index in the bit field leaving the bit flag unchanged.
+    ///
+    /// If the bit field is unset, the index is set to the given value and the
+    /// bit flag is set to false.
+    #[allow(unused)]
+    fn set_index(self, index: usize) -> Self {
+        let u = U::from_usize(index).expect("index too large");
+        let msb = if self.is_none() {
+            U::zero()
+        } else {
+            self.0 & Self::msb_mask()
+        };
+        Self(u | msb)
+    }
+
+    /// Return the bit flag stored in the bit field.
+    fn bit_flag(self) -> Option<bool> {
+        if self.is_none() {
+            return None;
+        }
+        Some(self.0 & Self::msb_mask() != U::zero())
+    }
+
+    /// Set the bit flag in the bit field leaving the index unchanged.
+    ///
+    /// Panics if the bit field is unset.
+    fn set_bit_flag(self) -> Self {
+        assert!(!self.is_none(), "bit field is unset");
+
+        let msb = self.0 | Self::msb_mask();
+        Self(msb)
+    }
+
+    /// Unset the bit flag in the bit field leaving the index unchanged.
+    ///
+    /// Panics if the bit field is unset.
+    #[allow(unused)]
+    fn unset_bit_flag(self) -> Self {
+        assert!(!self.is_none(), "bit field is unset");
+
+        let msb = self.0 & !Self::msb_mask();
+        Self(msb)
+    }
+
+    fn flip_bit_flag(self) -> Self {
+        Self(self.0 ^ Self::msb_mask())
+    }
+
+    fn unpack(self) -> Option<(usize, bool)> {
+        let ind = self.index()?;
+        let flag = self.bit_flag()?;
+        Some((ind, flag))
+    }
+
+    fn pack(data: Option<(usize, bool)>) -> Self {
+        match data {
+            Some((ind, flag)) => Self::new(ind, flag),
+            None => Self::new_none(),
+        }
+    }
+
+    fn msb_mask() -> U {
+        U::max_value() - (U::max_value() >> 1)
+    }
+
+    /// Whether the bit field is unset.
+    fn is_none(self) -> bool {
+        self == Self::new_none()
     }
 }
 
 #[cfg(feature = "serde")]
-impl<T: Serialize + Index> Serialize for ShiftedIndex<T> {
+impl<U: Serialize + Unsigned> Serialize for BitField<U> {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        self.index().serialize(serializer)
+        self.unpack().serialize(serializer)
     }
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T: Index + Deserialize<'de>> Deserialize<'de> for ShiftedIndex<T> {
+impl<'de, U: Unsigned + Deserialize<'de>> Deserialize<'de> for BitField<U> {
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        usize::deserialize(deserializer).map(ShiftedIndex::new)
+        Deserialize::deserialize(deserializer).map(BitField::pack)
     }
 }
 
-impl<T: Index> TryFrom<usize> for ShiftedIndex<T> {
+impl<U: Unsigned> TryFrom<usize> for BitField<U> {
     type Error = IndexError;
 
     #[inline]
     fn try_from(index: usize) -> Result<Self, Self::Error> {
-        if index > Self::MAX {
+        if index > Self::max_index() {
             Err(IndexError { index })
         } else {
-            Ok(Self::new(index))
+            Ok(Self::new(index, false))
         }
     }
 }
 
-impl<T: Index> From<ShiftedIndex<T>> for usize {
+impl<U: Unsigned> From<BitField<U>> for usize {
     #[inline]
-    fn from(index: ShiftedIndex<T>) -> Self {
-        index.index()
+    fn from(bit_field: BitField<U>) -> Self {
+        bit_field.index().expect("invalid index")
     }
 }
 
@@ -342,14 +392,12 @@ pub struct IndexError {
 
 #[cfg(test)]
 mod tests {
-    use std::u16;
-
     use super::*;
 
     #[test]
     fn test_opposite() {
-        let incoming = PortOffset::<u32>::new_incoming(5);
-        let outgoing = PortOffset::<u32>::new_outgoing(5);
+        let incoming = PortOffset::<u16>::new_incoming(5);
+        let outgoing = PortOffset::<u16>::new_outgoing(5);
 
         assert_eq!(incoming.opposite(), outgoing);
         assert_eq!(outgoing.opposite(), incoming);
@@ -358,19 +406,42 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    #[case(0u16)]
-    #[case(1u16)]
-    #[case(16u16)]
-    fn test_shifted_index_new_and_index_u16(#[case] value: u16) {
-        let idx = ShiftedIndex::<u16>::new(value as usize);
-        assert_eq!(idx.index(), value as usize);
-        assert_eq!(idx.0, value + 1);
+    #[case(0u16, false)]
+    #[case(1u16, false)]
+    #[case(16u16, true)]
+    fn test_create_bitfield(#[case] value: u16, #[case] flag: bool) {
+        let idx = BitField::<u16>::new(value as usize, flag);
+        assert_eq!(idx.index().unwrap(), value as usize);
+        assert_eq!(idx.bit_flag().unwrap(), flag);
+
+        let idx = idx.flip_bit_flag();
+        assert_eq!(idx.bit_flag().unwrap(), !flag);
+
+        let idx = idx.set_bit_flag();
+        assert!(idx.bit_flag().unwrap());
+
+        let idx = idx.unset_bit_flag();
+        assert!(!idx.bit_flag().unwrap());
+
+        let idx = idx.set_index(2 * value as usize);
+        assert_eq!(idx.index().unwrap(), 2 * value as usize);
     }
 
     #[test]
-    fn test_shifted_index_try_from_usize_error() {
-        let value = u16::MAX;
-        assert!(ShiftedIndex::<u16>::try_from(value as usize).is_err());
+    fn test_from_usize_overflow_error() {
+        let value = u16::MAX >> 1;
+        assert!(BitField::<u16>::try_from(value as usize).is_err());
+    }
+
+    #[test]
+    fn test_bitfield_none() {
+        let idx = BitField::<u16>::new_none();
+        assert_eq!(idx.index(), None);
+        assert_eq!(idx.bit_flag(), None);
+
+        let idx = idx.set_index(1);
+        assert_eq!(idx.index().unwrap(), 1);
+        assert!(!idx.bit_flag().unwrap());
     }
 
     #[test]
@@ -379,14 +450,14 @@ mod tests {
         let idx = 42;
         let incoming = PortOffset::<u16>::new_incoming(idx);
         assert_eq!(incoming.direction(), Direction::Incoming);
-        assert_eq!(incoming.index(), idx as usize);
+        assert_eq!(incoming.index(), { idx });
         assert_eq!(format!("{:?}", incoming), "Incoming(42)");
 
         // Test Outgoing direction
         let idx2 = 99;
         let outgoing = PortOffset::<u16>::new_outgoing(idx2);
         assert_eq!(outgoing.direction(), Direction::Outgoing);
-        assert_eq!(outgoing.index(), idx2 as usize);
+        assert_eq!(outgoing.index(), { idx2 });
         assert_eq!(format!("{:?}", outgoing), "Outgoing(99)");
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,392 @@
+//! Index types for nodes and ports.
+
+use delegate::delegate;
+use thiserror::Error;
+
+#[cfg(feature = "pyo3")]
+use pyo3::prelude::*;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::Direction;
+
+/// Index type that can be used to index nodes and ports.
+///
+/// Currently, implementations are provided for `usize`, `u64`, `u32`, `u16`,
+/// and `u8`. Choose the bit width that suits your needs.
+pub trait Index: Copy {
+    const MAX: usize;
+
+    fn try_from_usize(index: usize) -> Result<Self, IndexError>;
+
+    fn to_usize(self) -> usize;
+
+    fn set_msb(self) -> Self;
+
+    fn unset_msb(self) -> Self;
+
+    fn msb(self) -> bool;
+
+    fn flip_msb(self) -> Self {
+        if self.msb() {
+            self.unset_msb()
+        } else {
+            self.set_msb()
+        }
+    }
+}
+
+macro_rules! impl_index_for {
+    ($ty:ty) => {
+        impl Index for $ty {
+            const MAX: usize = <$ty>::MAX as usize;
+
+            fn try_from_usize(index: usize) -> Result<Self, IndexError> {
+                if index > <Self as Index>::MAX {
+                    Err(IndexError { index })
+                } else {
+                    Ok(index as Self)
+                }
+            }
+
+            fn to_usize(self) -> usize {
+                self as usize
+            }
+
+            fn set_msb(self) -> Self {
+                self | (1 << (<$ty>::BITS - 1))
+            }
+
+            fn unset_msb(self) -> Self {
+                self & !(1 << (<$ty>::BITS - 1))
+            }
+
+            fn msb(self) -> bool {
+                self & (1 << (<$ty>::BITS - 1)) != 0
+            }
+        }
+    };
+}
+
+impl_index_for!(usize);
+impl_index_for!(u64);
+impl_index_for!(u32);
+impl_index_for!(u16);
+impl_index_for!(u8);
+
+/// Index of a node within a `PortGraph`.
+///
+/// For an index type with n bits, the index value will be restricted to at
+/// most `2^n - 1` . The all null value is reserved for null-pointer optimisation.
+#[repr(transparent)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T: Serialize + Index",
+        deserialize = "T: Deserialize<'de> + Index"
+    ))
+)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "pyo3", derive(IntoPyObject))]
+pub struct NodeIndex<T>(ShiftedIndex<T>);
+
+/// Index of a port within a `PortGraph`.
+///
+/// For an index type with n bits, the index value will be restricted to at
+/// most `2^n - 1` . The all null value is reserved for null-pointer optimisation.
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T: Serialize + Index",
+        deserialize = "T: Deserialize<'de> + Index"
+    ))
+)]
+#[cfg_attr(feature = "pyo3", derive(IntoPyObject))]
+pub struct PortIndex<T>(ShiftedIndex<T>);
+
+// Wraps the ShiftedIndex API for NodeIndex and PortIndex.
+macro_rules! index_impls {
+    ($name:ident) => {
+        impl<T: Index> $name<T> {
+            /// Maximum allowed index.
+            const MAX: usize = ShiftedIndex::<T>::MAX;
+
+            /// Creates a new index from a `usize`.
+            ///
+            /// # Panics
+            ///
+            /// Panics if the index is greater than `Self::MAX`.
+            #[inline]
+            pub fn new(index: usize) -> Self {
+                Self(ShiftedIndex::new(index))
+            }
+
+            delegate! {
+                to self.0 {
+                    /// Returns the index as a `T`.
+                    pub fn index(&self) -> usize;
+                }
+            }
+        }
+
+        impl<T: Index> TryFrom<usize> for $name<T> {
+            type Error = IndexError;
+
+            #[inline]
+            fn try_from(index: usize) -> Result<Self, Self::Error> {
+                ShiftedIndex::try_from(index).map(Self)
+            }
+        }
+
+        impl<T: Index> From<$name<T>> for usize {
+            #[inline]
+            fn from(index: $name<T>) -> Self {
+                Self::from(index.0)
+            }
+        }
+
+        impl<T: Index> std::fmt::Debug for $name<T> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                // avoid unnecessary newlines in alternate mode
+                write!(f, concat!(stringify!($name), "({})"), self.index())
+            }
+        }
+    };
+}
+
+index_impls!(NodeIndex);
+index_impls!(PortIndex);
+
+impl<T: Index> Default for PortIndex<T> {
+    fn default() -> Self {
+        PortIndex::new(0)
+    }
+}
+
+/// Port offset in a node.
+///
+/// For an index type with n bits, the index value will be restricted to at
+/// most `2^(n-1)` . The most significant bit is reserved to store the direction
+/// of the offset, see [`PortOffset::direction`].
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct PortOffset<T>(T);
+
+impl<T: Index> PortOffset<T> {
+    /// Maximum allowed offset. One bit is reserved for the direction.
+    const MAX: usize = T::MAX >> 1;
+
+    /// Creates a new port offset.
+    #[inline(always)]
+    pub fn new(direction: Direction, offset: usize) -> Self {
+        match direction {
+            Direction::Incoming => Self::new_incoming(offset),
+            Direction::Outgoing => Self::new_outgoing(offset),
+        }
+    }
+
+    /// Creates a new incoming port offset.
+    #[inline(always)]
+    pub fn new_incoming(offset: usize) -> Self {
+        if offset > Self::MAX {
+            panic!("the offset is too large.")
+        }
+        let offset = T::try_from_usize(offset).expect("smaller than allowed MAX value");
+        Self(offset)
+    }
+
+    /// Creates a new outgoing port offset.
+    #[inline(always)]
+    pub fn new_outgoing(offset: usize) -> Self {
+        if offset > Self::MAX {
+            panic!("the offset is too large.")
+        }
+        let offset = T::try_from_usize(offset).expect("smaller than allowed MAX value");
+        offset.set_msb(); // mark that this is an outgoing port
+        Self(offset)
+    }
+
+    /// Returns the direction of the port.
+    #[inline(always)]
+    pub fn direction(self) -> Direction {
+        if self.0.msb() {
+            Direction::Outgoing
+        } else {
+            Direction::Incoming
+        }
+    }
+
+    /// Returns the offset of the port.
+    #[inline(always)]
+    pub fn index(self) -> usize {
+        let offset = self.0;
+        offset.unset_msb().to_usize()
+    }
+
+    /// Returns the opposite port offset.
+    ///
+    /// This maps `PortOffset::Incoming(x)` to `PortOffset::Outgoing(x)` and
+    /// vice versa.
+    #[inline(always)]
+    pub fn opposite(&self) -> Self {
+        Self(self.0.flip_msb())
+    }
+}
+
+impl<T: Index> Default for PortOffset<T> {
+    fn default() -> Self {
+        PortOffset::new_outgoing(0)
+    }
+}
+
+impl<T: Index> std::fmt::Debug for PortOffset<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.direction() {
+            Direction::Incoming => write!(f, "Incoming({})", self.index()),
+            Direction::Outgoing => write!(f, "Outgoing({})", self.index()),
+        }
+    }
+}
+
+/// An index, stored as shifted by one.
+///
+/// The range of the index is [0, MAX - 1], but is represented internally by the
+/// interval [1, MAX]. This allows the *null pointer optimization* so that the
+/// compiler can represent `Option<ShiftedIndex<T>>` in as much space as `T` by
+/// itself.
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "pyo3", derive(IntoPyObject))]
+struct ShiftedIndex<T>(T);
+
+impl<T: Index> ShiftedIndex<T> {
+    /// Maximum allowed index.
+    const MAX: usize = T::MAX - 1;
+
+    /// Returns the index as a `T`.
+    pub fn index(&self) -> usize {
+        self.0.to_usize() - 1
+    }
+
+    /// Creates a new node index from a `usize`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is greater than `Self::MAX`.
+    #[inline]
+    pub fn new(index: usize) -> Self {
+        if index > Self::MAX {
+            panic!("the index is too large.")
+        }
+        debug_assert!(index + 1 <= T::MAX);
+        let index = T::try_from_usize(index + 1).expect("smaller than allowed MAX value");
+        Self(index)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T: Serialize + Index> Serialize for ShiftedIndex<T> {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.index().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T: Index + Deserialize<'de>> Deserialize<'de> for ShiftedIndex<T> {
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        usize::deserialize(deserializer).map(ShiftedIndex::new)
+    }
+}
+
+impl<T: Index> TryFrom<usize> for ShiftedIndex<T> {
+    type Error = IndexError;
+
+    #[inline]
+    fn try_from(index: usize) -> Result<Self, Self::Error> {
+        if index > Self::MAX {
+            Err(IndexError { index })
+        } else {
+            Ok(Self::new(index))
+        }
+    }
+}
+
+impl<T: Index> From<ShiftedIndex<T>> for usize {
+    #[inline]
+    fn from(index: ShiftedIndex<T>) -> Self {
+        index.index()
+    }
+}
+
+/// Error indicating a `NodeIndex`, `PortIndex`, or `Direction` is too large.
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+#[error("the index {index} is too large.")]
+pub struct IndexError {
+    pub(crate) index: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::u16;
+
+    use super::*;
+
+    #[test]
+    fn test_opposite() {
+        let incoming = PortOffset::<u32>::new_incoming(5);
+        let outgoing = PortOffset::<u32>::new_outgoing(5);
+
+        assert_eq!(incoming.opposite(), outgoing);
+        assert_eq!(outgoing.opposite(), incoming);
+    }
+
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(0u16)]
+    #[case(1u16)]
+    #[case(16u16)]
+    fn test_shifted_index_new_and_index_u16(#[case] value: u16) {
+        let idx = ShiftedIndex::<u16>::new(value as usize);
+        assert_eq!(idx.index(), value as usize);
+        assert_eq!(idx.0, value + 1);
+    }
+
+    #[test]
+    fn test_shifted_index_try_from_usize_error() {
+        let value = u16::MAX;
+        assert!(ShiftedIndex::<u16>::try_from(value as usize).is_err());
+    }
+
+    #[test]
+    fn test_port_offset_direction_and_index() {
+        // Test Incoming direction
+        let idx = 42;
+        let incoming = PortOffset::<u16>::new_incoming(idx);
+        assert_eq!(incoming.direction(), Direction::Incoming);
+        assert_eq!(incoming.index(), idx as usize);
+        assert_eq!(format!("{:?}", incoming), "Incoming(42)");
+
+        // Test Outgoing direction
+        let idx2 = 99;
+        let outgoing = PortOffset::<u16>::new_outgoing(idx2);
+        assert_eq!(outgoing.direction(), Direction::Outgoing);
+        assert_eq!(outgoing.index(), idx2 as usize);
+        assert_eq!(format!("{:?}", outgoing), "Outgoing(99)");
+    }
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -451,13 +451,13 @@ mod tests {
         let incoming = PortOffset::<u16>::new_incoming(idx);
         assert_eq!(incoming.direction(), Direction::Incoming);
         assert_eq!(incoming.index(), { idx });
-        assert_eq!(format!("{:?}", incoming), "Incoming(42)");
+        assert_eq!(format!("{incoming:?}"), "Incoming(42)");
 
         // Test Outgoing direction
         let idx2 = 99;
         let outgoing = PortOffset::<u16>::new_outgoing(idx2);
         assert_eq!(outgoing.direction(), Direction::Outgoing);
         assert_eq!(outgoing.index(), { idx2 });
-        assert_eq!(format!("{:?}", outgoing), "Outgoing(99)");
+        assert_eq!(format!("{outgoing:?}"), "Outgoing(99)");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! use ::portgraph::algorithms::{toposort, TopoSort};
 //!
 //! // Create a graph with two nodes, each with two input and two output ports
-//! let mut graph = PortGraph::new();
+//! let mut graph: PortGraph = PortGraph::new();
 //! let node_a = graph.add_node(2, 2);
 //! let node_b = graph.add_node(2, 2);
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,18 +53,17 @@
 //!   graph component structures.
 //! - `pyo3` enables Python bindings.
 //!
-use std::num::NonZeroU32;
-use thiserror::Error;
 
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 pub mod algorithms;
 pub mod boundary;
 pub mod hierarchy;
+pub mod index;
 pub mod multiportgraph;
 pub mod portgraph;
 pub mod render;
@@ -78,6 +77,8 @@ pub mod proptest;
 
 #[doc(inline)]
 pub use crate::hierarchy::Hierarchy;
+#[doc(inline)]
+pub use crate::index::{IndexError, NodeIndex, PortIndex, PortOffset};
 #[doc(inline)]
 pub use crate::multiportgraph::MultiPortGraph;
 #[doc(inline)]
@@ -134,274 +135,5 @@ impl TryFrom<usize> for Direction {
             1 => Ok(Direction::Outgoing),
             index => Err(IndexError { index }),
         }
-    }
-}
-
-/// Index of a node within a `PortGraph`.
-///
-/// Restricted to be at most `2^31 - 1` to allow more efficient encodings of the port graph structure.
-/// This type admits the *null pointer optimization* so that `Option<NodeIndex>` takes as much space
-/// as a `NodeIndex` by itself.
-#[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "pyo3", derive(IntoPyObject))]
-pub struct NodeIndex(NonZeroU32);
-
-#[cfg(feature = "serde")]
-impl Serialize for NodeIndex {
-    #[inline]
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.index().serialize(serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for NodeIndex {
-    #[inline]
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        usize::deserialize(deserializer).map(NodeIndex::new)
-    }
-}
-
-impl NodeIndex {
-    /// Maximum allowed index. The higher bit is reserved for efficient encoding of the port graph.
-    const MAX: usize = (u32::MAX / 2) as usize - 1;
-
-    /// Creates a new node index from a `usize`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the index is greater than `2^31 - 2`.
-    #[inline]
-    pub fn new(index: usize) -> Self {
-        index.try_into().unwrap()
-    }
-
-    /// Returns the index as a `usize`.
-    #[inline]
-    pub fn index(self) -> usize {
-        self.into()
-    }
-}
-
-impl From<NodeIndex> for usize {
-    #[inline]
-    fn from(index: NodeIndex) -> Self {
-        u32::from(index.0) as usize - 1
-    }
-}
-
-impl TryFrom<usize> for NodeIndex {
-    type Error = IndexError;
-
-    #[inline]
-    fn try_from(index: usize) -> Result<Self, Self::Error> {
-        if index > Self::MAX {
-            Err(IndexError { index })
-        } else {
-            // SAFETY: The value cannot be zero
-            Ok(Self(unsafe { NonZeroU32::new_unchecked(1 + index as u32) }))
-        }
-    }
-}
-
-impl std::fmt::Debug for NodeIndex {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // avoid unnecessary newlines in alternate mode
-        write!(f, "NodeIndex({})", self.index())
-    }
-}
-
-/// Index of a port within a `PortGraph`.
-///
-/// Restricted to be at most `2^31 - 1` to allow more efficient encodings of the port graph structure.
-/// This type admits the *null pointer optimization* so that `Option<PortIndex>` takes as much space
-/// as a `PortIndex` by itself.
-#[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "pyo3", derive(IntoPyObject))]
-pub struct PortIndex(NonZeroU32);
-
-#[cfg(feature = "serde")]
-impl Serialize for PortIndex {
-    #[inline]
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.index().serialize(serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for PortIndex {
-    #[inline]
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        usize::deserialize(deserializer).map(PortIndex::new)
-    }
-}
-
-impl PortIndex {
-    /// Maximum allowed index. The higher bit is reserved for efficient encoding of the port graph.
-    const MAX: usize = (u32::MAX / 2) as usize - 1;
-
-    /// Creates a new port index from a `usize`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the index is greater than `2^31 - 2`.
-    #[inline]
-    pub fn new(index: usize) -> Self {
-        index.try_into().unwrap()
-    }
-
-    /// Returns the index as a `usize`.
-    #[inline]
-    pub fn index(self) -> usize {
-        self.into()
-    }
-}
-
-impl From<PortIndex> for usize {
-    #[inline]
-    fn from(index: PortIndex) -> Self {
-        u32::from(index.0) as usize - 1
-    }
-}
-
-impl TryFrom<usize> for PortIndex {
-    type Error = IndexError;
-
-    #[inline]
-    fn try_from(index: usize) -> Result<Self, Self::Error> {
-        if index > Self::MAX {
-            Err(IndexError { index })
-        } else {
-            // SAFETY: The value cannot be zero
-            Ok(Self(unsafe { NonZeroU32::new_unchecked(1 + index as u32) }))
-        }
-    }
-}
-
-impl std::fmt::Debug for PortIndex {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // avoid unnecessary newlines in alternate mode
-        write!(f, "PortIndex({})", self.index())
-    }
-}
-
-impl Default for PortIndex {
-    fn default() -> Self {
-        PortIndex::new(0)
-    }
-}
-
-/// Error indicating a `NodeIndex`, `PortIndex`, or `Direction` is too large.
-#[derive(Debug, Clone, Error, PartialEq, Eq)]
-#[error("the index {index} is too large.")]
-pub struct IndexError {
-    index: usize,
-}
-
-/// Port offset in a node
-#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-pub struct PortOffset {
-    index: u16,
-    direction: Direction,
-}
-
-impl PortOffset {
-    /// Creates a new port offset.
-    #[inline(always)]
-    pub fn new(direction: Direction, offset: usize) -> Self {
-        match direction {
-            Direction::Incoming => Self::new_incoming(offset),
-            Direction::Outgoing => Self::new_outgoing(offset),
-        }
-    }
-
-    /// Creates a new incoming port offset.
-    #[inline(always)]
-    pub fn new_incoming(offset: usize) -> Self {
-        Self {
-            index: offset
-                .try_into()
-                .expect("The offset must be less than 2^16."),
-            direction: Direction::Incoming,
-        }
-    }
-
-    /// Creates a new outgoing port offset.
-    #[inline(always)]
-    pub fn new_outgoing(offset: usize) -> Self {
-        Self {
-            index: offset
-                .try_into()
-                .expect("The offset must be less than 2^16."),
-            direction: Direction::Outgoing,
-        }
-    }
-
-    /// Returns the direction of the port.
-    #[inline(always)]
-    pub fn direction(self) -> Direction {
-        self.direction
-    }
-
-    /// Returns the offset of the port.
-    #[inline(always)]
-    pub fn index(self) -> usize {
-        self.index as usize
-    }
-
-    /// Returns the opposite port offset.
-    ///
-    /// This maps `PortOffset::Incoming(x)` to `PortOffset::Outgoing(x)` and
-    /// vice versa.
-    #[inline(always)]
-    pub fn opposite(&self) -> Self {
-        Self {
-            index: self.index,
-            direction: self.direction.reverse(),
-        }
-    }
-}
-
-impl Default for PortOffset {
-    fn default() -> Self {
-        PortOffset::new_outgoing(0)
-    }
-}
-
-impl std::fmt::Debug for PortOffset {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.direction {
-            Direction::Incoming => write!(f, "Incoming({})", self.index),
-            Direction::Outgoing => write!(f, "Outgoing({})", self.index),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_opposite() {
-        let incoming = PortOffset::new_incoming(5);
-        let outgoing = PortOffset::new_outgoing(5);
-
-        assert_eq!(incoming.opposite(), outgoing);
-        assert_eq!(outgoing.opposite(), incoming);
     }
 }

--- a/src/proptest.rs
+++ b/src/proptest.rs
@@ -108,11 +108,11 @@ where
     })
 }
 
-fn graph_from_edges<G: PortMut + LinkMut + Default>(edges: &[Edge]) -> G {
+fn graph_from_edges<G: PortMut<PortOffsetBase = u16> + LinkMut + Default>(edges: &[Edge]) -> G {
     let mut map_vertices = BTreeMap::new();
     let mut in_port_counts = BTreeMap::new();
     let mut out_port_counts = BTreeMap::new();
-    let mut add_port = |v, p: PortOffset| {
+    let mut add_port = |v, p: PortOffset<G::PortOffsetBase>| {
         let (max, port) = match p.direction() {
             Direction::Incoming => (in_port_counts.entry(v).or_insert(0), p.index()),
             Direction::Outgoing => (out_port_counts.entry(v).or_insert(0), p.index()),

--- a/src/render/mermaid.rs
+++ b/src/render/mermaid.rs
@@ -24,7 +24,7 @@ const INDENTATION_SEPARATOR: &str = "    ";
 /// ```rust
 /// # use portgraph::{LinkMut, PortGraph, PortMut, PortView, Hierarchy};
 /// # use portgraph::render::MermaidFormat;
-/// let mut graph = PortGraph::new();
+/// let mut graph: PortGraph = PortGraph::new();
 /// let n1 = graph.add_node(3, 2);
 /// let n2 = graph.add_node(0, 1);
 /// let n3 = graph.add_node(1, 0);
@@ -213,7 +213,7 @@ pub trait MermaidFormat: LinkView + Sized {
     /// ```rust
     /// # use portgraph::{LinkMut, PortGraph, PortMut, PortView, Hierarchy};
     /// # use portgraph::render::MermaidFormat;
-    /// let mut graph = PortGraph::new();
+    /// let mut graph: PortGraph = PortGraph::new();
     /// let n1 = graph.add_node(3, 2);
     /// let n2 = graph.add_node(0, 1);
     /// let n3 = graph.add_node(1, 0);

--- a/src/unmanaged.rs
+++ b/src/unmanaged.rs
@@ -17,7 +17,7 @@
 //! ```
 //! # use ::portgraph::*;
 //!
-//! let mut graph = PortGraph::new();
+//! let mut graph: PortGraph = PortGraph::new();
 //! let mut node_weights = UnmanagedDenseMap::<NodeIndex, usize>::new();
 //! let mut port_weights = UnmanagedDenseMap::<PortIndex, isize>::new();
 //!

--- a/src/view/filter.rs
+++ b/src/view/filter.rs
@@ -107,6 +107,8 @@ impl<G, Ctx> PortView for FilteredGraph<G, NodeFilter<Ctx>, LinkFilter<Ctx>, Ctx
 where
     G: PortView + Clone,
 {
+    type PortOffsetBase = G::PortOffsetBase;
+
     #[inline]
     fn contains_node(&'_ self, node: NodeIndex) -> bool {
         self.graph.contains_node(node) && (self.node_filter)(node, &self.context)
@@ -151,15 +153,15 @@ where
         to self.graph {
             fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction>;
             fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
-            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<crate::PortOffset>;
-            fn port_index(&self, node: NodeIndex, offset: crate::PortOffset) -> Option<PortIndex>;
+            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<crate::PortOffset<Self::PortOffsetBase>>;
+            fn port_index(&self, node: NodeIndex, offset: crate::PortOffset<Self::PortOffsetBase>) -> Option<PortIndex>;
             fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex> + Clone;
             fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone;
             fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
-            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset> + Clone;
-            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset<Self::PortOffsetBase>> + Clone;
+            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset<Self::PortOffsetBase>> + Clone;
             fn node_capacity(&self) -> usize;
             fn port_capacity(&self) -> usize;
             fn node_port_capacity(&self, node: NodeIndex) -> usize;

--- a/src/view/flat_region.rs
+++ b/src/view/flat_region.rs
@@ -111,6 +111,8 @@ impl<G> PortView for FlatRegion<'_, G>
 where
     G: PortView + Clone,
 {
+    type PortOffsetBase = G::PortOffsetBase;
+
     #[inline(always)]
     fn contains_node(&'_ self, node: NodeIndex) -> bool {
         (self.include_root && node == self.region_root)
@@ -167,15 +169,15 @@ where
         to self.graph {
             fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction>;
             fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
-            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<crate::PortOffset>;
-            fn port_index(&self, node: NodeIndex, offset: crate::PortOffset) -> Option<PortIndex>;
+            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<crate::PortOffset<Self::PortOffsetBase>>;
+            fn port_index(&self, node: NodeIndex, offset: crate::PortOffset<Self::PortOffsetBase>) -> Option<PortIndex>;
             fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex> + Clone;
             fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone;
             fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
-            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset> + Clone;
-            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset<Self::PortOffsetBase>> + Clone;
+            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset<Self::PortOffsetBase>> + Clone;
             fn node_port_capacity(&self, node: NodeIndex) -> usize;
         }
     }
@@ -290,7 +292,7 @@ mod test {
 
     #[test]
     fn single_node_region() {
-        let mut graph = PortGraph::new();
+        let mut graph: PortGraph = PortGraph::new();
         let root = graph.add_node(0, 0);
 
         let hierarchy = Hierarchy::new();

--- a/src/view/refs.rs
+++ b/src/view/refs.rs
@@ -10,19 +10,21 @@ use delegate::delegate;
 use super::{LinkMut, LinkView, MultiMut, MultiView, PortMut, PortView};
 
 impl<G: PortView> PortView for &G {
+    type PortOffsetBase = G::PortOffsetBase;
+
     delegate! {
         to (*self) {
             fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction>;
             fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
-            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<PortOffset>;
-            fn port_index(&self, node: NodeIndex, offset: PortOffset) -> Option<PortIndex>;
+            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<PortOffset<Self::PortOffsetBase>>;
+            fn port_index(&self, node: NodeIndex, offset: PortOffset<Self::PortOffsetBase>) -> Option<PortIndex>;
             fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex> + Clone;
             fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone;
             fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
-            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset> + Clone;
-            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset<Self::PortOffsetBase>> + Clone;
+            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset<Self::PortOffsetBase>> + Clone;
             fn contains_node(&self, node: NodeIndex) -> bool;
             fn contains_port(&self, port: PortIndex) -> bool;
             fn is_empty(&self) -> bool;
@@ -38,19 +40,21 @@ impl<G: PortView> PortView for &G {
 }
 
 impl<G: PortView> PortView for &mut G {
+    type PortOffsetBase = G::PortOffsetBase;
+
     delegate! {
         to (&**self) {
             fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction>;
             fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
-            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<PortOffset>;
-            fn port_index(&self, node: NodeIndex, offset: PortOffset) -> Option<PortIndex>;
+            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<PortOffset<Self::PortOffsetBase>>;
+            fn port_index(&self, node: NodeIndex, offset: PortOffset<Self::PortOffsetBase>) -> Option<PortIndex>;
             fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex> + Clone;
             fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone;
             fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
-            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset> + Clone;
-            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset<Self::PortOffsetBase>> + Clone;
+            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset<Self::PortOffsetBase>> + Clone;
             fn contains_node(&self, node: NodeIndex) -> bool;
             fn contains_port(&self, port: PortIndex) -> bool;
             fn is_empty(&self) -> bool;
@@ -136,7 +140,11 @@ impl<G: PortMut> PortMut for &mut G {
 impl<G: LinkMut> LinkMut for &mut G {
     delegate! {
         to (*self) {
-            fn link_ports(&mut self, port_a: PortIndex, port_b: PortIndex) -> Result<(Self::LinkEndpoint, Self::LinkEndpoint), LinkError>;
+            fn link_ports(
+                &mut self,
+                port_a: PortIndex,
+                port_b: PortIndex,
+            ) -> Result<(Self::LinkEndpoint, Self::LinkEndpoint), LinkError<G::PortOffsetBase>>;
             fn unlink_port(&mut self, port: PortIndex) -> Option<Self::LinkEndpoint>;
         }
     }
@@ -145,7 +153,11 @@ impl<G: LinkMut> LinkMut for &mut G {
 impl<G: MultiMut> MultiMut for &mut G {
     delegate! {
         to (*self) {
-            fn link_subports(&mut self, subport_from: Self::LinkEndpoint, subport_to: Self::LinkEndpoint) -> Result<(), LinkError>;
+            fn link_subports(
+                &mut self,
+                subport_from: Self::LinkEndpoint,
+                subport_to: Self::LinkEndpoint,
+            ) -> Result<(), LinkError<G::PortOffsetBase>>;
             fn unlink_subport(&mut self, subport: Self::LinkEndpoint) -> Option<Self::LinkEndpoint>;
         }
     }

--- a/src/view/region.rs
+++ b/src/view/region.rs
@@ -146,6 +146,8 @@ impl<G> PortView for Region<'_, G>
 where
     G: PortView + Clone,
 {
+    type PortOffsetBase = G::PortOffsetBase;
+
     #[inline(always)]
     fn contains_node(&'_ self, node: NodeIndex) -> bool {
         self.is_descendant(node)
@@ -198,15 +200,15 @@ where
         to self.graph {
             fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction>;
             fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
-            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<crate::PortOffset>;
-            fn port_index(&self, node: NodeIndex, offset: crate::PortOffset) -> Option<PortIndex>;
+            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<crate::PortOffset<G::PortOffsetBase>>;
+            fn port_index(&self, node: NodeIndex, offset: crate::PortOffset<G::PortOffsetBase>) -> Option<PortIndex>;
             fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex> + Clone;
             fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone;
             fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
-            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset> + Clone;
-            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset<G::PortOffsetBase>> + Clone;
+            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset<G::PortOffsetBase>> + Clone;
             fn node_port_capacity(&self, node: NodeIndex) -> usize;
         }
     }
@@ -321,7 +323,7 @@ mod test {
 
     #[test]
     fn single_node_region() {
-        let mut graph = PortGraph::new();
+        let mut graph: PortGraph = PortGraph::new();
         let root = graph.add_node(0, 0);
 
         let hierarchy = Hierarchy::new();

--- a/src/view/subgraph.rs
+++ b/src/view/subgraph.rs
@@ -170,6 +170,8 @@ fn collect_boundary_ports<G: LinkView>(
 }
 
 impl<G: PortView> PortView for Subgraph<G> {
+    type PortOffsetBase = G::PortOffsetBase;
+
     #[inline(always)]
     fn contains_node(&'_ self, node: NodeIndex) -> bool {
         self.nodes.contains(&node)
@@ -222,15 +224,15 @@ impl<G: PortView> PortView for Subgraph<G> {
         to self.graph {
             fn port_direction(&self, port: impl Into<PortIndex>) -> Option<Direction>;
             fn port_node(&self, port: impl Into<PortIndex>) -> Option<NodeIndex>;
-            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<PortOffset>;
-            fn port_index(&self, node: NodeIndex, offset: PortOffset) -> Option<PortIndex>;
+            fn port_offset(&self, port: impl Into<PortIndex>) -> Option<PortOffset<Self::PortOffsetBase>>;
+            fn port_index(&self, node: NodeIndex, offset: PortOffset<Self::PortOffsetBase>) -> Option<PortIndex>;
             fn ports(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortIndex> + Clone;
             fn all_ports(&self, node: NodeIndex) -> impl Iterator<Item = PortIndex> + Clone;
             fn input(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn output(&self, node: NodeIndex, offset: usize) -> Option<PortIndex>;
             fn num_ports(&self, node: NodeIndex, direction: Direction) -> usize;
-            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset> + Clone;
-            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset> + Clone;
+            fn port_offsets(&self, node: NodeIndex, direction: Direction) -> impl Iterator<Item = PortOffset<Self::PortOffsetBase>> + Clone;
+            fn all_port_offsets(&self, node: NodeIndex) -> impl Iterator<Item = PortOffset<Self::PortOffsetBase>> + Clone;
             fn node_port_capacity(&self, node: NodeIndex) -> usize;
         }
     }
@@ -701,7 +703,7 @@ mod tests {
 
     #[test]
     fn test_is_convex_line() {
-        let mut graph = PortGraph::new();
+        let mut graph: PortGraph = PortGraph::new();
         let n0 = graph.add_node(0, 1);
         let n1 = graph.add_node(1, 1);
         let n2 = graph.add_node(1, 0);
@@ -719,7 +721,7 @@ mod tests {
 
     #[test]
     fn test_disconnected_components() {
-        let mut graph = PortGraph::new();
+        let mut graph: PortGraph = PortGraph::new();
         let n0 = graph.add_node(0, 1);
         let n1 = graph.add_node(1, 0);
         graph.link_nodes(n0, 0, n1, 0).unwrap();
@@ -765,7 +767,7 @@ mod tests {
 
     #[test]
     fn test_copy_in_parent() {
-        let mut graph = PortGraph::new();
+        let mut graph: PortGraph = PortGraph::new();
         // First component: n0 -> n1 + cycle
         let n0 = graph.add_node(0, 1);
         let n1 = graph.add_node(2, 1);
@@ -821,7 +823,7 @@ mod tests {
     #[case(Direction::Incoming)]
     #[case(Direction::Outgoing)]
     fn test_copy_in_parent_bad_boundary(#[case] edge: Direction) {
-        let mut graph = PortGraph::new();
+        let mut graph: PortGraph = PortGraph::new();
         let n0 = graph.add_node(0, 1);
         let n1 = graph.add_node(1, 1);
         let n2 = graph.add_node(1, 0);
@@ -858,7 +860,7 @@ mod tests {
 
     #[test]
     fn test_copy_in_parent_multi_input() {
-        let mut graph = MultiPortGraph::new();
+        let mut graph: MultiPortGraph = MultiPortGraph::new();
         let n0 = graph.add_node(0, 1);
         let n1 = graph.add_node(1, 1);
         let n2 = graph.add_node(1, 0);
@@ -896,7 +898,7 @@ mod tests {
 
     #[test]
     fn test_copy_in_parent_multi_output() {
-        let mut graph = MultiPortGraph::new();
+        let mut graph: MultiPortGraph = MultiPortGraph::new();
         let n0 = graph.add_node(0, 1);
         let n1 = graph.add_node(1, 1);
         let n2 = graph.add_node(1, 0);

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -12,7 +12,7 @@
 //!
 //! ```
 //! # use ::portgraph::*;
-//! let mut graph = PortGraph::new();
+//! let mut graph: PortGraph = PortGraph::new();
 //! let mut weights = Weights::<usize, isize>::new();
 //!
 //! // The weights must be set manually.


### PR DESCRIPTION
Closes #213

PortGraph and MultiPortGraph are now generic on `NodeIndex`, `PortIndex` and `PortOffset`. This allows the user to fix the size of these fields, using the unsigned integer of their choice.

To smooth the transition to fully generic indices, we currently only implement most features in this crate for `NodeIndex` and `PortIndex` fixed to `u32`. Generic `PortOffset` is supported in `PortView` and all related traits.

BREAKING CHANGE: `PortGraph` and `MultiPortGraph` now take generic type parameters. The default choices correspond to the old types. `PortView` has a new associated type `PortOffsetBase`.