### PR TITLE
fix: Serialise/Deserialise for indices is backwards compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,7 @@ dependencies = [
  "rmp-serde",
  "rstest",
  "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -1054,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,18 +1385,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ rmp-serde = "1.1.1"
 rstest = "0.25.0"
 itertools = "0.14.0"
 insta = "1.43.0"
+serde_json = "1.0.141"
 
 [[bench]]
 name = "criterion_benches"

--- a/src/boundary.rs
+++ b/src/boundary.rs
@@ -447,7 +447,7 @@ impl PortOrdering {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use std::collections::BTreeSet;
 
     use crate::view::Subgraph;
@@ -495,7 +495,7 @@ mod test {
     /// 4 -> 5 -> 6 -> 7
     /// ```
     #[fixture]
-    fn graph() -> MultiPortGraph {
+    pub(crate) fn graph() -> MultiPortGraph {
         let mut graph = MultiPortGraph::new();
         let nodes: Vec<NodeIndex> = (0..8).map(|_| graph.add_node(4, 4)).collect();
         // Horizontal links between from port 0 to port 0
@@ -519,7 +519,7 @@ mod test {
     /// 0 -> 1 -> 2 -> 3 -> ..
     /// ```
     #[fixture]
-    fn line_graph<const N: usize>() -> (MultiPortGraph, [NodeIndex; N]) {
+    pub(crate) fn line_graph<const N: usize>() -> (MultiPortGraph, [NodeIndex; N]) {
         let mut graph = MultiPortGraph::new();
         let nodes: Vec<NodeIndex> = (0..N).map(|_| graph.add_node(4, 4)).collect();
         for (u, v) in (0..N).zip(1..N) {

--- a/src/index.rs
+++ b/src/index.rs
@@ -667,3 +667,16 @@ mod tests {
         assert_eq!(format!("{outgoing:?}"), "Outgoing(99)");
     }
 }
+
+#[cfg(test)]
+#[cfg(feature = "serde")]
+mod test_serde {
+    use crate::{boundary::test::line_graph, MultiPortGraph, NodeIndex};
+    use rstest::rstest;
+
+    #[rstest]
+    fn test_serde_node_index(line_graph: (MultiPortGraph, [NodeIndex; 5])) {
+        let (graph, _) = line_graph;
+        insta::assert_snapshot!(serde_json::to_string_pretty(&graph).unwrap(),)
+    }
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -7,9 +7,6 @@ use thiserror::Error;
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
 use crate::Direction;
 
 /// Index of a node within a `PortGraph`.
@@ -20,14 +17,6 @@ use crate::Direction;
 /// Use with one of `usize`, `u64`, `u32`, `u16` and `u8`. Choose the bit width
 /// that suits your needs.
 #[repr(transparent)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(
-    feature = "serde",
-    serde(bound(
-        serialize = "U: Serialize + Unsigned",
-        deserialize = "U: Deserialize<'de> + Unsigned"
-    ))
-)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "pyo3", derive(IntoPyObject))]
 pub struct NodeIndex<U = u32>(BitField<U>);
@@ -38,14 +27,6 @@ pub struct NodeIndex<U = u32>(BitField<U>);
 /// most `2^(n-1) - 1` . The all null value is reserved for null-pointer optimisation.
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(
-    feature = "serde",
-    serde(bound(
-        serialize = "U: Serialize + Unsigned",
-        deserialize = "U: Deserialize<'de> + Unsigned"
-    ))
-)]
 #[cfg_attr(feature = "pyo3", derive(IntoPyObject))]
 pub struct PortIndex<U = u32>(BitField<U>);
 
@@ -104,6 +85,28 @@ macro_rules! index_impls {
                 unsafe { &mut *(self as *mut BitField<U> as *mut $name<U>) }
             }
         }
+
+        #[cfg(feature = "serde")]
+        impl<U: serde::Serialize + Unsigned> serde::Serialize for $name<U> {
+            #[inline]
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                self.index().serialize(serializer)
+            }
+        }
+
+        #[cfg(feature = "serde")]
+        impl<'de, U: Unsigned + serde::Deserialize<'de>> serde::Deserialize<'de> for $name<U> {
+            #[inline]
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                Ok($name::new(serde::Deserialize::deserialize(deserializer)?))
+            }
+        }
     };
 }
 
@@ -121,14 +124,6 @@ impl<U: Unsigned> Default for PortIndex<U> {
 /// Uses the spare bit flag of the NodeIndex to store the `None` case.
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(
-    feature = "serde",
-    serde(bound(
-        serialize = "U: Serialize + Unsigned",
-        deserialize = "U: Deserialize<'de> + Unsigned"
-    ))
-)]
 pub struct MaybeNodeIndex<U>(BitField<U>);
 
 /// Equivalent to `Option<PortIndex<U>>` but stored within the size of `U`.
@@ -136,14 +131,6 @@ pub struct MaybeNodeIndex<U>(BitField<U>);
 /// Uses the spare bit flag of the PortIndex to store the `None` case.
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(
-    feature = "serde",
-    serde(bound(
-        serialize = "U: Serialize + Unsigned",
-        deserialize = "U: Deserialize<'de> + Unsigned"
-    ))
-)]
 pub struct MaybePortIndex<U>(BitField<U>);
 
 macro_rules! maybe_index_impls {
@@ -263,6 +250,32 @@ macro_rules! maybe_index_impls {
                 self.to_option().into_iter()
             }
         }
+
+        #[cfg(feature = "serde")]
+        impl<U: serde::Serialize + Unsigned> serde::Serialize for $maybe_index<U> {
+            #[inline]
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                self.to_option().serialize(serializer)
+            }
+        }
+
+        #[cfg(feature = "serde")]
+        impl<'de, U: Unsigned + serde::Deserialize<'de>> serde::Deserialize<'de>
+            for $maybe_index<U>
+        {
+            #[inline]
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                Ok($maybe_index::new(serde::Deserialize::deserialize(
+                    deserializer,
+                )?))
+            }
+        }
     };
 }
 
@@ -282,14 +295,6 @@ impl MaybeNodeIndex<u32> {
 /// of the offset, see [`PortOffset::direction`].
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(
-    feature = "serde",
-    serde(bound(
-        serialize = "U: Serialize + Unsigned",
-        deserialize = "U: Deserialize<'de> + Unsigned"
-    ))
-)]
 pub struct PortOffset<U = u16>(BitField<U>);
 
 impl<U: Unsigned> PortOffset<U> {
@@ -353,6 +358,55 @@ impl<U: Unsigned> std::fmt::Debug for PortOffset<U> {
         match self.direction() {
             Direction::Incoming => write!(f, "Incoming({})", self.index()),
             Direction::Outgoing => write!(f, "Outgoing({})", self.index()),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde_port_offset_impl {
+    use super::*;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Serialize, Deserialize)]
+    struct PortOffsetSer {
+        index: usize,
+        direction: Direction,
+    }
+
+    impl<U: Unsigned> From<PortOffset<U>> for PortOffsetSer {
+        fn from(port_offset: PortOffset<U>) -> Self {
+            Self {
+                index: port_offset.index(),
+                direction: port_offset.direction(),
+            }
+        }
+    }
+
+    impl<U: Unsigned> From<PortOffsetSer> for PortOffset<U> {
+        fn from(port_offset: PortOffsetSer) -> Self {
+            Self::new(port_offset.direction, port_offset.index)
+        }
+    }
+
+    impl<U: Serialize + Unsigned> Serialize for PortOffset<U> {
+        #[inline]
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let port_offset: PortOffsetSer = (*self).into();
+            port_offset.serialize(serializer)
+        }
+    }
+
+    impl<'de, U: Unsigned + Deserialize<'de>> Deserialize<'de> for PortOffset<U> {
+        #[inline]
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let port_offset: PortOffsetSer = Deserialize::deserialize(deserializer)?;
+            Ok(port_offset.into())
         }
     }
 }
@@ -504,21 +558,6 @@ impl<U: Unsigned> BitField<U> {
     }
 
     #[inline(always)]
-    fn unpack(self) -> Option<(usize, bool)> {
-        let ind = self.index()?;
-        let flag = self.bit_flag()?;
-        Some((ind, flag))
-    }
-
-    #[inline(always)]
-    fn pack(data: Option<(usize, bool)>) -> Self {
-        match data {
-            Some((ind, flag)) => Self::new(ind, flag),
-            None => Self::new_none(),
-        }
-    }
-
-    #[inline(always)]
     fn msb_mask() -> U {
         U::max_value() - (U::max_value() >> 1)
     }
@@ -527,28 +566,6 @@ impl<U: Unsigned> BitField<U> {
     #[inline(always)]
     fn is_none(self) -> bool {
         self == Self::new_none()
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<U: Serialize + Unsigned> Serialize for BitField<U> {
-    #[inline]
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.unpack().serialize(serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de, U: Unsigned + Deserialize<'de>> Deserialize<'de> for BitField<U> {
-    #[inline]
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Deserialize::deserialize(deserializer).map(BitField::pack)
     }
 }
 

--- a/src/snapshots/portgraph__index__test_serde__serde_node_index.snap
+++ b/src/snapshots/portgraph__index__test_serde__serde_node_index.snap
@@ -1,0 +1,160 @@
+---
+source: src/index.rs
+expression: "serde_json::to_string_pretty(&graph).unwrap()"
+---
+{
+  "graph": {
+    "node_meta": [
+      {
+        "n": {
+          "first_port": 0,
+          "incoming": 5,
+          "outgoing": 4,
+          "capacity": 8
+        }
+      },
+      {
+        "n": {
+          "first_port": 8,
+          "incoming": 5,
+          "outgoing": 4,
+          "capacity": 8
+        }
+      },
+      {
+        "n": {
+          "first_port": 16,
+          "incoming": 5,
+          "outgoing": 4,
+          "capacity": 8
+        }
+      },
+      {
+        "n": {
+          "first_port": 24,
+          "incoming": 5,
+          "outgoing": 4,
+          "capacity": 8
+        }
+      },
+      {
+        "n": {
+          "first_port": 32,
+          "incoming": 5,
+          "outgoing": 4,
+          "capacity": 8
+        }
+      }
+    ],
+    "port_link": [
+      null,
+      null,
+      null,
+      null,
+      8,
+      null,
+      null,
+      null,
+      4,
+      null,
+      null,
+      null,
+      16,
+      null,
+      null,
+      null,
+      12,
+      null,
+      null,
+      null,
+      24,
+      null,
+      null,
+      null,
+      20,
+      null,
+      null,
+      null,
+      32,
+      null,
+      null,
+      null,
+      28,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    ],
+    "port_meta": [
+      1,
+      1,
+      1,
+      1,
+      2147483649,
+      2147483649,
+      2147483649,
+      2147483649,
+      2,
+      2,
+      2,
+      2,
+      2147483650,
+      2147483650,
+      2147483650,
+      2147483650,
+      3,
+      3,
+      3,
+      3,
+      2147483651,
+      2147483651,
+      2147483651,
+      2147483651,
+      4,
+      4,
+      4,
+      4,
+      2147483652,
+      2147483652,
+      2147483652,
+      2147483652,
+      5,
+      5,
+      5,
+      5,
+      2147483653,
+      2147483653,
+      2147483653,
+      2147483653
+    ],
+    "node_free": null,
+    "port_free": [],
+    "node_count": 5,
+    "port_count": 40,
+    "link_count": 4,
+    "_marker": null
+  },
+  "multiport": {
+    "order": "bitvec::order::Lsb0",
+    "head": {
+      "width": 64,
+      "index": 0
+    },
+    "bits": 0,
+    "data": []
+  },
+  "copy_node": {
+    "order": "bitvec::order::Lsb0",
+    "head": {
+      "width": 64,
+      "index": 0
+    },
+    "bits": 0,
+    "data": []
+  },
+  "copy_node_count": 0,
+  "subport_count": 0
+}


### PR DESCRIPTION
https://github.com/CQCL/portgraph/pull/230 broke serialisation of `NodeIndex`, `PortIndex` and `PortOffset`. This PR restores the previous serialisation.

Should I mark this PR as breaking, even though it does not change any APIs? Sorry for the double breakage. The previous simpler serialisation was better, and this will also break less user code in the long run (minus the once that have already upgraded).

EDIT: We are yanking 0.15, restoring the old serialisation format is thus non-breaking.
