### PR TITLE
chore: Fix new clippy lint

### DIFF
--- a/src/proptest.rs
+++ b/src/proptest.rs
@@ -87,7 +87,7 @@ prop_compose! {
 /// Returns a tuple (g, node) so that strategies for portgraph generation can
 /// be composed with this function. E.g, use as follows:
 ///
-/// ```
+/// ```ignore
 /// use proptest::prelude::*;
 ///
 /// proptest! {


### PR DESCRIPTION
```bash
error: unit tests in doctest are not executed
  --> src/proptest.rs:94:9
   |
94 | ///     #[test]
   |         ^^^^^^^
   |
```

This is just a usage example, so the block can be ignored for doctests