### PR TITLE
chore: Fix MSRV test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
     permissions:
       pull-requests: write
     secrets:
-      # Post as @hugrbot when possible, fallback to the github user for fork PRs.
+      # Post as @hugrbot when possible, fallback to the GitHub Actions user for fork PRs.
       GITHUB_PAT: ${{ secrets.HUGRBOT_PAT || github.token }}
 
   coverage:


### PR DESCRIPTION
Adds more transitive dependency versions to the resolution list, to find a working minimal dependency resolution.

drive-by: Add fallback token to the semver-checks call, so it works in fork PRs too.